### PR TITLE
DataChannel の接続タイムアウト時間を変更

### DIFF
--- a/Sora/Sora.cs
+++ b/Sora/Sora.cs
@@ -53,7 +53,7 @@ public class Sora : IDisposable
         // DataChannel を使ったシグナリングを利用するかどうか
         public bool DataChannelSignaling = false;
         // DataChannel のデータが何秒間やって来なければ切断したとみなすか
-        public int DataChannelSignalingTimeout = 30;
+        public int DataChannelSignalingTimeout = 180;
         // DataChannel の接続が確立した後は、WebSocket が切断されても Sora との接続を確立したままとするかどうか
         public bool IgnoreDisconnectWebsocket = false;
         // DataChannel の接続が確立したら、クライアントから明示的に WebSocket を切断するかどうか

--- a/src/sora_signaling.h
+++ b/src/sora_signaling.h
@@ -49,7 +49,7 @@ struct SoraSignalingConfig {
   int spotlight_number = 0;
   bool simulcast = false;
   bool data_channel_signaling = false;
-  int data_channel_signaling_timeout = 30;
+  int data_channel_signaling_timeout = 180;
   bool ignore_disconnect_websocket = false;
   bool close_websocket = true;
 


### PR DESCRIPTION
- sora.cs の DataChannelSignalingTimeout を 30 から 180 に修正しました
- sora_signaling.h の data_channel_signaling_timeout を 30 から 180 に修正しました