### PR TITLE
[doc] Linux 利用時に必要なパッケージを追記する

### DIFF
--- a/doc/USE.md
+++ b/doc/USE.md
@@ -39,7 +39,7 @@ Sora Unity SDK のインストール完了後 [ANDROID.md](ANDROID.md) をお読
 
 ### Linux で Sora Unity SDK を使ってみる
 
-`libva2` パッケージおよび `libva-drm2` パッケージの apt によるインストール、
+`libva-drm2` パッケージの apt によるインストール、
 Sora Unity SDK のインストール完了後使うことができます。
 
 ## FAQ

--- a/doc/USE.md
+++ b/doc/USE.md
@@ -6,7 +6,7 @@ Sora Unity SDK を使ってみるためにまずはサンプル集を試して�
 
 [Sora Unity SDK サンプル集](https://github.com/shiguredo/sora-unity-sdk-samples)
 
-## インストール
+## Sora Unity SDK のインストール
 
 サンプルを試して動くことが確認できたら、Sora Unity SDK を導入したいご自身のプロジェクトにインストールしてみます。
 
@@ -27,15 +27,20 @@ GitHub アカウントを用意して[Sora Labo のドキュメント](https://g
 
 ### macOS / Windows で Sora Unity SDK を使ってみる
 
-インストール完了後使うことができます。
+Sora Unity SDK のインストール完了後使うことができます。
 
 ### iOS で Sora Unity SDK を使ってみる
 
-インストール完了後 [IOS.md](IOS.md) をお読みください。
+Sora Unity SDK のインストール完了後 [IOS.md](IOS.md) をお読みください。
 
 ### Android で Sora Unity SDK を使ってみる
 
-インストール完了後 [ANDROID.md](ANDROID.md) をお読みください。
+Sora Unity SDK のインストール完了後 [ANDROID.md](ANDROID.md) をお読みください。
+
+### Linux で Sora Unity SDK を使ってみる
+
+`libva2` パッケージおよび `libva-drm2` パッケージのインストール、
+Sora Unity SDK のインストール完了後使うことができます。
 
 ## FAQ
 

--- a/doc/USE.md
+++ b/doc/USE.md
@@ -39,7 +39,7 @@ Sora Unity SDK のインストール完了後 [ANDROID.md](ANDROID.md) をお読
 
 ### Linux で Sora Unity SDK を使ってみる
 
-`libva2` パッケージおよび `libva-drm2` パッケージのインストール、
+`libva2` パッケージおよび `libva-drm2` パッケージの apt によるインストール、
 Sora Unity SDK のインストール完了後使うことができます。
 
 ## FAQ


### PR DESCRIPTION
linux で利用する際に必要なパッケージを追記しました。

apt で `libva-drm2` をインストールしたときに依存パッケージとして `libva2` も入りましたが何を利用しているかがわかりやすいように「`libva2` パッケージおよび `libva-drm2` パッケージ」と分けて記載しました。

一緒でもいいのでは、などコメントあればお願いします。