### PR TITLE
Android の インターネットアクセスパーミッションについて追記する

### DIFF
--- a/doc/ANDROID.md
+++ b/doc/ANDROID.md
@@ -43,3 +43,6 @@ Player Settings -> Other Settings -> Target Architectures で ARM64 にチェッ
 
 - Pixel 3 で解像度が 16 の倍数でない時に映像が乱れる問題があります。
     - [1084702 - Mobile Chrome on Pixel 3 has video corruption for non-16-aligned resolutions in WebRTC calls : Hardware VP8 encoder bug - chromium](https://bugs.chromium.org/p/chromium/issues/detail?id=1084702)
+
+- Development Build では接続できていたがリリースビルドで接続できない。
+    - インターネット接続のパーミッションが付与されていない可能性があります。[Project Settings - Player - Android タブ - Other Settings - Configration - Internet Access] の設定を `Require` に設定されているかいるかご確認ください。

--- a/doc/ANDROID.md
+++ b/doc/ANDROID.md
@@ -45,4 +45,4 @@ Player Settings -> Other Settings -> Target Architectures で ARM64 にチェッ
     - [1084702 - Mobile Chrome on Pixel 3 has video corruption for non-16-aligned resolutions in WebRTC calls : Hardware VP8 encoder bug - chromium](https://bugs.chromium.org/p/chromium/issues/detail?id=1084702)
 
 - Development Build では接続できていたがリリースビルドで接続できない。
-    - インターネット接続のパーミッションが付与されていない可能性があります。[Project Settings - Player - Android タブ - Other Settings - Configration - Internet Access] の設定を `Require` に設定されているかいるかご確認ください。
+    - インターネット接続のパーミッションが付与されていない可能性があります。[Project Settings - Player - Android タブ - Other Settings - Configration - Internet Access] の設定を `Require` に設定されているかご確認ください。

--- a/doc/ANDROID.md
+++ b/doc/ANDROID.md
@@ -7,31 +7,34 @@
 
 ## Android で使うために必要な設定
 
-### Android Plugin の設定変更をします。
+### Android Plugin の設定変更をします
 
 libSoraUnitySdk.so インスペクタの Platform settings -> Android の設定で CPU を ARM64 に変更して下さい。
 
 [![Image from Gyazo](https://i.gyazo.com/f7dbf0ebbd1b1567517b4fcd34ff1c97.png)](https://gyazo.com/f7dbf0ebbd1b1567517b4fcd34ff1c97)
 
-### Graphics APIs を設定します。
+### Graphics APIs を設定します
 
-####  Vulkan を使用したい場合
+#### Vulkan を使用したい場合
+
 Player Settings -> Other Settings の Graphics APIs で Vulkan を先頭にして下さい。
 
 [![Image from Gyazo](https://i.gyazo.com/bdd46d716499e312f3361b756e90b53c.png)](https://gyazo.com/bdd46d716499e312f3361b756e90b53c)
 
-####  OpenGLES を使用したい場合
+#### OpenGLES を使用したい場合
+
 Player Settings -> Other Settings の Graphics APIs で OpenGLES3 を先頭にして下さい。
 
 [![Image from Gyazo](https://i.gyazo.com/a3fe926948f72079cb663075c7968288.png)](https://gyazo.com/a3fe926948f72079cb663075c7968288)
 
-### Minimum API Level で Android 7.0 'Nougat' ( API level 24 ) 以上を設定します。
+### Minimum API Level で Android 7.0 'Nougat' ( API level 24 ) 以上を設定します
 
 Player Settings -> Other Settings -> Minimum API Level で Android 7.0 'Nougat' ( API level 24 ) を以上を選択してください。
 
 [![Image from Gyazo](https://i.gyazo.com/f14a796b9c2a1661cbb4ad39734b5cc5.png)](https://gyazo.com/f14a796b9c2a1661cbb4ad39734b5cc5)
 
-### Target Architectures で ARM64 を設定します。
+### Target Architectures で ARM64 を設定します
+
 Player Settings -> Other Settings -> Target Architectures で ARM64 にチェックをして下さい。
 
 [![Image from Gyazo](https://i.gyazo.com/de434b5dfff683dd3f9c306b9e9844bc.png)](https://gyazo.com/de434b5dfff683dd3f9c306b9e9844bc)
@@ -39,4 +42,4 @@ Player Settings -> Other Settings -> Target Architectures で ARM64 にチェッ
 ## そのほかの利用に関する注意点
 
 - Pixel 3 で解像度が 16 の倍数でない時に映像が乱れる問題があります。
-  - [1084702 - Mobile Chrome on Pixel 3 has video corruption for non-16-aligned resolutions in WebRTC calls : Hardware VP8 encoder bug - chromium](https://bugs.chromium.org/p/chromium/issues/detail?id=1084702)
+    - [1084702 - Mobile Chrome on Pixel 3 has video corruption for non-16-aligned resolutions in WebRTC calls : Hardware VP8 encoder bug - chromium](https://bugs.chromium.org/p/chromium/issues/detail?id=1084702)


### PR DESCRIPTION
lint の結果を反映する変更が含まれています。
実際に追記をしたのはファイル最後の 2 行です。

実際に記載した設定を変更することで動作が変わることは確認済みです

- required を選択した場合 ->  Development Build : OFF で接続可能
- auto を選択した場合 ->  Development Build : OFF で接続できない

画像で示すことも考えましたがレアなケースなのでノイズにならないよう、文字のみでの説明にしました。ご意見あれば是非お願いします。