### PR TITLE
接続中にキャプチャラを切り替える機能を実装

### DIFF
--- a/proto/sora_conf_internal.proto
+++ b/proto/sora_conf_internal.proto
@@ -37,6 +37,15 @@ message ForwardingFilter {
     repeated Rules rules = 2;
 }
 
+message CameraConfig {
+    int32 capturer_type = 17;
+    int64 unity_camera_texture = 18;
+    string video_capturer_device = 19;
+    int32 video_width = 22;
+    int32 video_height = 23;
+    int32 video_fps = 24;
+}
+
 message ConnectConfig {
     string unity_version = 1;
     repeated string signaling_url = 2;
@@ -54,14 +63,9 @@ message ConnectConfig {
     bool enable_simulcast = 14;
     bool simulcast = 15;
     string simulcast_rid = 16;
-    int32 capturer_type = 17;
-    int64 unity_camera_texture = 18;
-    string video_capturer_device = 19;
+    CameraConfig camera_config = 17;
     bool video = 20;
     bool audio = 21;
-    int32 video_width = 22;
-    int32 video_height = 23;
-    int32 video_fps = 24;
     string video_codec_type = 25;
     string video_vp9_params = 250;
     string video_av1_params = 251;

--- a/src/sora.cpp
+++ b/src/sora.cpp
@@ -558,7 +558,16 @@ void Sora::DoSwitchCamera(const sora_conf::internal::CameraConfig& cc) {
   void* env = sora::GetJNIEnv();
   void* android_context = GetAndroidApplicationContext(env);
 
+#if defined(SORA_UNITY_SDK_ANDROID)
+  if (capturer_ != nullptr && capturer_type_ == 0) {
+    static_cast<sora::AndroidCapturer*>(capturer_.get())->Stop();
+  }
+#endif
+  if (capturer_ != nullptr && capturer_type_ != 0) {
+    static_cast<UnityCameraCapturer*>(capturer_.get())->Stop();
+  }
   capturer_ = nullptr;
+
   auto capturer = CreateVideoCapturer(
       cc.capturer_type, (void*)cc.unity_camera_texture,
       cc.video_capturer_device, cc.video_width, cc.video_height, cc.video_fps,

--- a/src/sora.cpp
+++ b/src/sora.cpp
@@ -66,6 +66,7 @@ Sora::~Sora() {
   capturer_ = nullptr;
   unity_adm_ = nullptr;
 
+  video_sender_ = nullptr;
   audio_track_ = nullptr;
   video_track_ = nullptr;
   connection_context_ = nullptr;
@@ -145,6 +146,40 @@ void Sora::DispatchEvents() {
     }
     f();
   }
+}
+
+static sora_conf::VideoFrame VideoFrameToConfig(
+    const webrtc::VideoFrame& frame) {
+  sora_conf::VideoFrame f;
+  f.baseptr = reinterpret_cast<int64_t>(&frame);
+  f.id = frame.id();
+  f.timestamp_us = frame.timestamp_us();
+  f.timestamp = frame.timestamp();
+  f.ntp_time_ms = frame.ntp_time_ms();
+  f.rotation = (int)frame.rotation();
+  auto& v = f.video_frame_buffer;
+  auto vfb = frame.video_frame_buffer();
+  v.baseptr = reinterpret_cast<int64_t>(vfb.get());
+  v.type = (sora_conf::VideoFrameBuffer::Type)vfb->type();
+  v.width = vfb->width();
+  v.height = vfb->height();
+  if (vfb->type() == webrtc::VideoFrameBuffer::Type::kI420) {
+    auto p = vfb->GetI420();
+    v.i420_stride_y = p->StrideY();
+    v.i420_stride_u = p->StrideU();
+    v.i420_stride_v = p->StrideV();
+    v.i420_data_y = reinterpret_cast<int64_t>(p->DataY());
+    v.i420_data_u = reinterpret_cast<int64_t>(p->DataU());
+    v.i420_data_v = reinterpret_cast<int64_t>(p->DataV());
+  }
+  if (vfb->type() == webrtc::VideoFrameBuffer::Type::kNV12) {
+    auto p = vfb->GetNV12();
+    v.nv12_stride_y = p->StrideY();
+    v.nv12_stride_uv = p->StrideUV();
+    v.nv12_data_y = reinterpret_cast<int64_t>(p->DataY());
+    v.nv12_data_uv = reinterpret_cast<int64_t>(p->DataUV());
+  }
+  return f;
 }
 
 void Sora::Connect(const sora_conf::internal::ConnectConfig& cc) {
@@ -302,43 +337,17 @@ void Sora::DoConnect(const sora_conf::internal::ConnectConfig& cc,
     if (on_capturer_frame_) {
       on_frame = [on_frame =
                       on_capturer_frame_](const webrtc::VideoFrame& frame) {
-        sora_conf::VideoFrame f;
-        f.baseptr = reinterpret_cast<int64_t>(&frame);
-        f.id = frame.id();
-        f.timestamp_us = frame.timestamp_us();
-        f.timestamp = frame.timestamp();
-        f.ntp_time_ms = frame.ntp_time_ms();
-        f.rotation = (int)frame.rotation();
-        auto& v = f.video_frame_buffer;
-        auto vfb = frame.video_frame_buffer();
-        v.baseptr = reinterpret_cast<int64_t>(vfb.get());
-        v.type = (sora_conf::VideoFrameBuffer::Type)vfb->type();
-        v.width = vfb->width();
-        v.height = vfb->height();
-        if (vfb->type() == webrtc::VideoFrameBuffer::Type::kI420) {
-          auto p = vfb->GetI420();
-          v.i420_stride_y = p->StrideY();
-          v.i420_stride_u = p->StrideU();
-          v.i420_stride_v = p->StrideV();
-          v.i420_data_y = reinterpret_cast<int64_t>(p->DataY());
-          v.i420_data_u = reinterpret_cast<int64_t>(p->DataU());
-          v.i420_data_v = reinterpret_cast<int64_t>(p->DataV());
-        }
-        if (vfb->type() == webrtc::VideoFrameBuffer::Type::kNV12) {
-          auto p = vfb->GetNV12();
-          v.nv12_stride_y = p->StrideY();
-          v.nv12_stride_uv = p->StrideUV();
-          v.nv12_data_y = reinterpret_cast<int64_t>(p->DataY());
-          v.nv12_data_uv = reinterpret_cast<int64_t>(p->DataUV());
-        }
+        sora_conf::VideoFrame f = VideoFrameToConfig(frame);
         on_frame(jsonif::to_json(f));
       };
     }
 
     auto capturer = CreateVideoCapturer(
-        cc.capturer_type, (void*)cc.unity_camera_texture,
-        cc.video_capturer_device, cc.video_width, cc.video_height, cc.video_fps,
-        on_frame, signaling_thread_.get(), env, android_context);
+        cc.camera_config.capturer_type,
+        (void*)cc.camera_config.unity_camera_texture,
+        cc.camera_config.video_capturer_device, cc.camera_config.video_width,
+        cc.camera_config.video_height, cc.camera_config.video_fps, on_frame,
+        signaling_thread_.get(), env, android_context);
     if (!capturer) {
       on_disconnect((int)sora_conf::ErrorCode::INTERNAL_ERROR,
                     "Capturer Init Failed");
@@ -346,7 +355,7 @@ void Sora::DoConnect(const sora_conf::internal::ConnectConfig& cc,
     }
 
     capturer_ = capturer;
-    capturer_type_ = cc.capturer_type;
+    capturer_type_ = cc.camera_config.capturer_type;
 
     std::string audio_track_id = rtc::CreateRandomString(16);
     audio_track_ = factory_->CreateAudioTrack(
@@ -528,6 +537,45 @@ void Sora::Disconnect() {
     return;
   }
   signaling_->Disconnect();
+}
+
+void Sora::SwitchCamera(const sora_conf::internal::CameraConfig& cc) {
+  RTC_LOG(LS_INFO) << "SwitchCamera: " << jsonif::to_json(cc);
+  boost::asio::post(*ioc_, [self = shared_from_this(), cc = cc]() {
+    self->DoSwitchCamera(cc);
+  });
+}
+void Sora::DoSwitchCamera(const sora_conf::internal::CameraConfig& cc) {
+  std::function<void(const webrtc::VideoFrame& frame)> on_frame;
+  if (on_capturer_frame_) {
+    on_frame = [on_frame =
+                    on_capturer_frame_](const webrtc::VideoFrame& frame) {
+      sora_conf::VideoFrame f = VideoFrameToConfig(frame);
+      on_frame(jsonif::to_json(f));
+    };
+  }
+
+  void* env = sora::GetJNIEnv();
+  void* android_context = GetAndroidApplicationContext(env);
+
+  capturer_ = nullptr;
+  auto capturer = CreateVideoCapturer(
+      cc.capturer_type, (void*)cc.unity_camera_texture,
+      cc.video_capturer_device, cc.video_width, cc.video_height, cc.video_fps,
+      on_frame, signaling_thread_.get(), env, android_context);
+  if (!capturer) {
+    RTC_LOG(LS_ERROR) << "Failed to CreateVideoCapturer";
+    return;
+  }
+
+  capturer_ = capturer;
+  capturer_type_ = cc.capturer_type;
+
+  std::string video_track_id = rtc::CreateRandomString(16);
+  auto video_track = factory_->CreateVideoTrack(video_track_id, capturer.get());
+  renderer_->ReplaceTrack(video_track_.get(), video_track.get());
+  video_sender_->SetTrack(video_track.get());
+  video_track_ = video_track;
 }
 
 void Sora::RenderCallbackStatic(int event_id) {
@@ -791,6 +839,7 @@ void Sora::OnSetOffer(std::string offer) {
     webrtc::RTCErrorOr<rtc::scoped_refptr<webrtc::RtpSenderInterface>>
         video_result = signaling_->GetPeerConnection()->AddTrack(video_track_,
                                                                  {stream_id});
+    video_sender_ = video_result.value();
   }
 
   if (video_track_ != nullptr) {

--- a/src/sora.h
+++ b/src/sora.h
@@ -53,6 +53,7 @@ class Sora : public std::enable_shared_from_this<Sora>,
 
   void Connect(const sora_conf::internal::ConnectConfig& cc);
   void Disconnect();
+  void SwitchCamera(const sora_conf::internal::CameraConfig& cc);
 
   static void UNITY_INTERFACE_API RenderCallbackStatic(int event_id);
   int GetRenderCallbackEventID() const;
@@ -91,6 +92,7 @@ class Sora : public std::enable_shared_from_this<Sora>,
  private:
   void DoConnect(const sora_conf::internal::ConnectConfig& config,
                  std::function<void(int, std::string)> on_disconnect);
+  void DoSwitchCamera(const sora_conf::internal::CameraConfig& cc);
 
   static rtc::scoped_refptr<UnityAudioDevice> CreateADM(
       webrtc::TaskQueueFactory* task_queue_factory,
@@ -140,6 +142,7 @@ class Sora : public std::enable_shared_from_this<Sora>,
   std::unique_ptr<UnityRenderer> renderer_;
   rtc::scoped_refptr<webrtc::AudioTrackInterface> audio_track_;
   rtc::scoped_refptr<webrtc::VideoTrackInterface> video_track_;
+  rtc::scoped_refptr<webrtc::RtpSenderInterface> video_sender_;
   std::function<void(ptrid_t, std::string)> on_add_track_;
   std::function<void(ptrid_t, std::string)> on_remove_track_;
   std::function<void(std::string)> on_set_offer_;

--- a/src/unity.cpp
+++ b/src/unity.cpp
@@ -142,6 +142,13 @@ void sora_disconnect(void* p) {
   wsora->sora->Disconnect();
 }
 
+void sora_switch_camera(void* p, const char* config_json) {
+  auto wsora = (SoraWrapper*)p;
+  auto config =
+      jsonif::from_json<sora_conf::internal::CameraConfig>(config_json);
+  wsora->sora->SwitchCamera(config);
+}
+
 void* sora_get_texture_update_callback() {
   return (void*)&sora_unity_sdk::UnityRenderer::Sink::TextureUpdateCallback;
 }

--- a/src/unity.h
+++ b/src/unity.h
@@ -60,6 +60,7 @@ UNITY_INTERFACE_EXPORT void sora_set_on_capturer_frame(void* p,
 UNITY_INTERFACE_EXPORT void sora_dispatch_events(void* p);
 UNITY_INTERFACE_EXPORT void sora_connect(void* p, const char* config);
 UNITY_INTERFACE_EXPORT void sora_disconnect(void* p);
+UNITY_INTERFACE_EXPORT void sora_switch_camera(void* p, const char* config);
 UNITY_INTERFACE_EXPORT void* sora_get_texture_update_callback();
 UNITY_INTERFACE_EXPORT void sora_destroy(void* sora);
 

--- a/src/unity_renderer.cpp
+++ b/src/unity_renderer.cpp
@@ -19,6 +19,11 @@ UnityRenderer::Sink::~Sink() {
 ptrid_t UnityRenderer::Sink::GetSinkID() const {
   return ptrid_;
 }
+void UnityRenderer::Sink::SetTrack(webrtc::VideoTrackInterface* track) {
+  track_->RemoveSink(this);
+  track->AddOrUpdateSink(this, rtc::VideoSinkWants());
+  track_ = track;
+}
 
 rtc::scoped_refptr<webrtc::VideoFrameBuffer>
 UnityRenderer::Sink::GetFrameBuffer() {
@@ -105,6 +110,20 @@ ptrid_t UnityRenderer::RemoveTrack(webrtc::VideoTrackInterface* track) {
   auto sink_id = it->second->GetSinkID();
   sinks_.erase(std::remove_if(sinks_.begin(), sinks_.end(), f), sinks_.end());
   return sink_id;
+}
+
+void UnityRenderer::ReplaceTrack(webrtc::VideoTrackInterface* oldTrack,
+                                 webrtc::VideoTrackInterface* newTrack) {
+  RTC_LOG(LS_INFO) << "UnityRenderer::ReplaceTrack";
+  auto it = std::find_if(sinks_.begin(), sinks_.end(),
+                         [oldTrack](const VideoSinkVector::value_type& sink) {
+                           return sink.first == oldTrack;
+                         });
+  if (it == sinks_.end()) {
+    return;
+  }
+  it->first = newTrack;
+  it->second->SetTrack(newTrack);
 }
 
 }  // namespace sora_unity_sdk

--- a/src/unity_renderer.h
+++ b/src/unity_renderer.h
@@ -27,6 +27,7 @@ class UnityRenderer {
     Sink(webrtc::VideoTrackInterface* track);
     ~Sink();
     ptrid_t GetSinkID() const;
+    void SetTrack(webrtc::VideoTrackInterface* track);
 
    private:
     rtc::scoped_refptr<webrtc::VideoFrameBuffer> GetFrameBuffer();
@@ -47,6 +48,8 @@ class UnityRenderer {
  public:
   ptrid_t AddTrack(webrtc::VideoTrackInterface* track);
   ptrid_t RemoveTrack(webrtc::VideoTrackInterface* track);
+  void ReplaceTrack(webrtc::VideoTrackInterface* oldTrack,
+                    webrtc::VideoTrackInterface* newTrack);
 };
 
 }  // namespace sora_unity_sdk


### PR DESCRIPTION
こんな風に利用可能です。
```csharp
// デバイスカメラに切り替える場合
sora.SwitchCamera(CameraConfig.FromDeviceCamera(videoCapturerDevice, videoWidth, videoHeight, videoFps));
// Unity カメラに切り替える場合
sora.SwitchCamera(CameraConfig.FromUnityCamera(unityCamera, 16, videoWidth, videoHeight, videoFps));
```

また、`Sora.Config` に含まれていた以下の７つのフィールドは `Sora.CameraConfig` に移動しました（破壊的変更）。

- `CapturerType`
- `UnityCamera`
- `UnityCameraRenderTargetDepthBuffer`
- `VideoCapturerDevice`
- `VideoWidth`
- `VideoHeight`
- `VideoFps`

もしこれらのフィールドを以下のように `Sora.Config` に設定している場合、

```csharp
Sora.Config config = new Sora.Config()
{
    SignalingUrl = signalingUrl,
    SignalingUrlCandidate = signalingUrlCandidate,
    ChannelId = channelId,
    ClientId = clientId,
    BundleId = bundleId,
    ...
    CapturerType = Sora.CapturerType.DeviceCamera,
    VideoCapturerDevice = videoCapturerDevice,
    VideoWidth = videoWidth,
    VideoHeight = videoHeight,
    VideoFps = videoFps,
};
```

以下のように書き換える必要があります。

```csharp
Sora.Config config = new Sora.Config()
{
    SignalingUrl = signalingUrl,
    SignalingUrlCandidate = signalingUrlCandidate,
    ChannelId = channelId,
    ClientId = clientId,
    BundleId = bundleId,
    ...
    CameraConfig = new Sora.CameraConfig()
    {
        CapturerType = Sora.CapturerType.DeviceCamera,
        VideoCapturerDevice = videoCapturerDevice,
        VideoWidth = videoWidth,
        VideoHeight = videoHeight,
        VideoFps = videoFps,
    },
};
```
