### PR TITLE
Github Actions の `macos-12` を `macos-14` に変更する

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
         name:
           - macos_arm64
           - ios
-    runs-on: macos-12
+    runs-on: macos-14
     steps:
     - uses: actions/checkout@v4
     - name: Cache

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 ## develop
 
+- [UPDATE] Github Actions の `macos-12` を `macos-14` に変更する
+  - @miosakuma
+
 ## 2024.4.0 (2024-07-29)
 
 - [CHANGE] `--sora-dir`, `--sora-args` を `--local-sora-cpp-sdk-dir` と `--local-sora-cpp-sdk-args` に変更する


### PR DESCRIPTION
CI が通ったことを確認してマージします

---
This pull request includes an update to the GitHub Actions configuration and documentation to ensure compatibility with the latest macOS version.

Changes to GitHub Actions configuration:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L48-R48): Updated the `runs-on` parameter from `macos-12` to `macos-14` for better compatibility and performance.

Documentation updates:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R16): Added an entry to document the update of GitHub Actions from `macos-12` to `macos-14`.