### PR TITLE
ビデオコーデック、オーディオコーデックのデフォルト値を未指定とする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,11 +13,11 @@
 
 - [CHANGE] Sora.Config.VideoCodecType を Nullable 型に変更し、デフォルト値を `VP9` から未指定に変更する
   - 未指定の場合、シグナリング "type": "connect" でビデオコーデック指定を行わない
-  - ビデオコーデック指定を行わない場合は Sora のデフォルト値 `VP9` が利用されるため機能影響はない
+  - ビデオコーデック指定を行わない場合は Sora のデフォルト値 `VP9` が利用される
   - @miosakuma
-- [CHANGE] AudioCodecType のデフォルト値を `OPUS` から未指定に変更する
+- [CHANGE] Sora.Config.AudioCodecType を Nullable 型に変更し、デフォルト値を `OPUS` から未指定に変更する
   - 未指定の場合、シグナリング "type": "connect" でオーディオコーデック指定を行わない
-  - オーディオコーデック指定を行わない場合は Sora のデフォルト値 `OPUS` が利用されるため機能影響はない
+  - オーディオコーデック指定を行わない場合は Sora のデフォルト値 `OPUS` が利用される
   - @miosakuma
 - [UPDATE] Sora C++ SDK を `2025.2.0` に上げる
   - `CMAKE_VERSION` を `3.31.4` にアップデート

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,8 +11,17 @@
 
 ## develop
 
+- [CHANGE] VideoCodecType のデフォルト値を `VP9` から未指定に変更する
+  - 未指定の場合、シグナリング "type": "connect" でビデオコーデック指定を行わない
+  - ビデオコーデック指定を行わない場合は Sora のデフォルト値 `VP9` が利用されるため機能影響はない
+  - @miosakuma
+- [CHANGE] AudioCodecType のデフォルト値を `OPUS` から未指定に変更する
+  - 未指定の場合、シグナリング "type": "connect" でオーディオコーデック指定を行わない
+  - オーディオコーデック指定を行わない場合は Sora のデフォルト値 `OPUS` が利用されるため機能影響はない
+  - @miosakuma
 - [UPDATE] Sora C++ SDK を `2025.2.0` に上げる
   - `CMAKE_VERSION` を `3.31.4` にアップデート
+  - @torikizi
 
 ## 2025.1.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@
 
 ## develop
 
-- [CHANGE] VideoCodecType のデフォルト値を `VP9` から未指定に変更する
+- [CHANGE] Sora.Config.VideoCodecType を Nullable 型に変更し、デフォルト値を `VP9` から未指定に変更する
   - 未指定の場合、シグナリング "type": "connect" でビデオコーデック指定を行わない
   - ビデオコーデック指定を行わない場合は Sora のデフォルト値 `VP9` が利用されるため機能影響はない
   - @miosakuma

--- a/Sora/Sora.cs
+++ b/Sora/Sora.cs
@@ -178,7 +178,7 @@ public class Sora : IDisposable
         public CameraConfig CameraConfig = new CameraConfig();
         public bool Video = true;
         public bool Audio = true;
-        public VideoCodecType VideoCodecType = VideoCodecType.VP9;
+        public VideoCodecType? VideoCodecType;
         public string VideoVp9Params = "";
         public string VideoAv1Params = "";
         public string VideoH264Params = "";
@@ -205,7 +205,7 @@ public class Sora : IDisposable
         /// 指定したデバイスのスピーカーを利用することが出来ます。
         /// </remarks>
         public string AudioPlayoutDevice = "";
-        public AudioCodecType AudioCodecType = AudioCodecType.OPUS;
+        public AudioCodecType? AudioCodecType;
         public int AudioBitRate = 0;
         public string AudioStreamingLanguageCode = "";
 
@@ -402,7 +402,7 @@ public class Sora : IDisposable
         cc.camera_config.video_width = config.CameraConfig.VideoWidth;
         cc.camera_config.video_height = config.CameraConfig.VideoHeight;
         cc.camera_config.video_fps = config.CameraConfig.VideoFps;
-        cc.video_codec_type = config.VideoCodecType.ToString();
+        cc.video_codec_type = config.VideoCodecType == null ? "" :  config.VideoCodecType.ToString();
         cc.video_vp9_params = config.VideoVp9Params;
         cc.video_av1_params = config.VideoAv1Params;
         cc.video_h264_params = config.VideoH264Params;
@@ -411,7 +411,7 @@ public class Sora : IDisposable
         cc.unity_audio_output = config.UnityAudioOutput;
         cc.audio_recording_device = config.AudioRecordingDevice;
         cc.audio_playout_device = config.AudioPlayoutDevice;
-        cc.audio_codec_type = config.AudioCodecType.ToString();
+        cc.audio_codec_type = config.AudioCodecType == null ? "" : config.AudioCodecType.ToString();
         cc.audio_bit_rate = config.AudioBitRate;
         cc.audio_streaming_language_code = config.AudioStreamingLanguageCode;
         if (config.EnableDataChannelSignaling)


### PR DESCRIPTION
動作確認済みです

- [CHANGE] VideoCodecType のデフォルト値を `VP9` から未指定に変更する
  - 未指定の場合、シグナリング "type": "connect" でビデオコーデック指定を行わない
  - ビデオコーデック指定を行わない場合は Sora のデフォルト値 `VP9` が利用されるため機能影響はない
- [CHANGE] AudioCodecType のデフォルト値を `OPUS` から未指定に変更する
  - 未指定の場合、シグナリング "type": "connect" でオーディオコーデック指定を行わない
  - オーディオコーデック指定を行わない場合は Sora のデフォルト値 `OPUS` が利用されるため機能影響はない

---

This pull request includes changes to the `Sora` library to modify the default values for video and audio codec types. The most important changes include updating the default values for `VideoCodecType` and `AudioCodecType` to be unspecified, and adjusting the `Connect` method to handle these unspecified values properly.

### Changes to default codec types:

* [`Sora/Sora.cs`](diffhunk://#diff-701e62fce3b805129ca7d074c9a78551dc19c3b57e3d410475031dd6de25b666L181-R181): Changed the default value of `VideoCodecType` from `VP9` to unspecified (`VideoCodecType?`).
* [`Sora/Sora.cs`](diffhunk://#diff-701e62fce3b805129ca7d074c9a78551dc19c3b57e3d410475031dd6de25b666L208-R208): Changed the default value of `AudioCodecType` from `OPUS` to unspecified (`AudioCodecType?`).

### Adjustments in the `Connect` method:

* [`Sora/Sora.cs`](diffhunk://#diff-701e62fce3b805129ca7d074c9a78551dc19c3b57e3d410475031dd6de25b666L405-R405): Modified the `Connect` method to handle unspecified `VideoCodecType` by setting `cc.video_codec_type` to an empty string if `config.VideoCodecType` is null.
* [`Sora/Sora.cs`](diffhunk://#diff-701e62fce3b805129ca7d074c9a78551dc19c3b57e3d410475031dd6de25b666L414-R414): Modified the `Connect` method to handle unspecified `AudioCodecType` by setting `cc.audio_codec_type` to an empty string if `config.AudioCodecType` is null.

### Documentation updates:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R24): Documented the changes to the default values for `VideoCodecType` and `AudioCodecType`.