### PR TITLE
ubuntu-20.04 をビルドから外す

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -80,18 +80,18 @@
             "intelliSenseMode": "clang-x64"
         },
         {
-            "name": "ubuntu-20.04_x86_64 Release",
+            "name": "ubuntu-22.04_x86_64 Release",
             "includePath": [
                 "${workspaceFolder}/src",
-                "${workspaceFolder}/_install/ubuntu-20.04_x86_64/release/sora/include",
-                "${workspaceFolder}/_install/ubuntu-20.04_x86_64/release/boost/include",
-                "${workspaceFolder}/_install/ubuntu-20.04_x86_64/release/webrtc/include",
-                "${workspaceFolder}/_install/ubuntu-20.04_x86_64/release/webrtc/include/third_party/zlib",
-                "${workspaceFolder}/_install/ubuntu-20.04_x86_64/release/webrtc/include/third_party/abseil-cpp",
-                "${workspaceFolder}/_install/ubuntu-20.04_x86_64/release/webrtc/include/third_party/boringssl/src/include",
-                "${workspaceFolder}/_install/ubuntu-20.04_x86_64/release/webrtc/include/third_party/libyuv/include",
-                "${workspaceFolder}/_build/ubuntu-20.04_x86_64/release/sora_unity_sdk",
-                "${workspaceFolder}/_build/ubuntu-20.04_x86_64/release/sora_unity_sdk/proto/cpp"
+                "${workspaceFolder}/_install/ubuntu-22.04_x86_64/release/sora/include",
+                "${workspaceFolder}/_install/ubuntu-22.04_x86_64/release/boost/include",
+                "${workspaceFolder}/_install/ubuntu-22.04_x86_64/release/webrtc/include",
+                "${workspaceFolder}/_install/ubuntu-22.04_x86_64/release/webrtc/include/third_party/zlib",
+                "${workspaceFolder}/_install/ubuntu-22.04_x86_64/release/webrtc/include/third_party/abseil-cpp",
+                "${workspaceFolder}/_install/ubuntu-22.04_x86_64/release/webrtc/include/third_party/boringssl/src/include",
+                "${workspaceFolder}/_install/ubuntu-22.04_x86_64/release/webrtc/include/third_party/libyuv/include",
+                "${workspaceFolder}/_build/ubuntu-22.04_x86_64/release/sora_unity_sdk",
+                "${workspaceFolder}/_build/ubuntu-22.04_x86_64/release/sora_unity_sdk/proto/cpp"
             ],
             "defines": [
                 "WEBRTC_POSIX",

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,7 +28,9 @@
   - 未指定の場合、シグナリング "type": "connect" でオーディオコーデック指定を行わない
   - オーディオコーデック指定を行わない場合は Sora のデフォルト値 `OPUS` が利用される
   - @miosakuma
-- [CHANGE] 対応プラットフォームから `Ubuntu 20.04` を削除、 `Ubuntu 22.04` を追加
+- [CHANGE] `Ubuntu 22.04` をリリースに含める
+  - @miosakuma
+- [CHANGE] 対応プラットフォームから `Ubuntu 20.04` を削除
   - @miosakuma
 - [ADD] 利用するビデオコーデックを詳細に指定するための enum やクラス、関数などを追加
   - `Sora.VideoCodecImplementation` 列挙型

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
 ## develop
 
 - [CHANGE] Linux x86_64 版のビルドを `ubuntu-20.04_x86_64` から `ubuntu-22.04_x86_64` にあげる
+  - ビルドに関して `ubuntu-20.04_x86_64` を指定していた部分を `ubuntu-22.04_x86_64` だけに変更
   - @miosakuma
 - [CHANGE] Sora.Config.UseHardwareEncoder フラグを削除
   - 代わりに `Sora.Config.VideoCodecPreference` を利用して下さい

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,8 @@
   - 未指定の場合、シグナリング "type": "connect" でオーディオコーデック指定を行わない
   - オーディオコーデック指定を行わない場合は Sora のデフォルト値 `OPUS` が利用される
   - @miosakuma
+- [CHANGE] 対応プラットフォームから `Ubuntu 20.04` を削除、 `Ubuntu 22.04` を追加
+  - @miosakuma
 - [ADD] 利用するビデオコーデックを詳細に指定するための enum やクラス、関数などを追加
   - `Sora.VideoCodecImplementation` 列挙型
   - `Sora.VideoCodecCapabilityConfig` クラス
@@ -46,8 +48,6 @@
 - [CHANGE] Linux x86_64 と Android のビルド環境を `ubuntu-20.04` から `ubuntu-22.04` にあげる
   - @miosakuma
 - [CHANGE] GitHub Actions の package タスクを実行する環境を `ubuntu-20.04` から `ubuntu-22.04` にあげる
-  - @miosakuma
-- [CHANGE] 対応プラットフォームから `Ubuntu 20.04` を削除、 `Ubuntu 22.04` を追加
   - @miosakuma
 
 ## 2025.1.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,10 +51,6 @@ elseif (SORA_UNITY_SDK_PACKAGE STREQUAL "android")
   add_library(SoraUnitySdk SHARED)
 
   set(SORA_UNITY_SDK_PLATFORM Android)
-elseif (SORA_UNITY_SDK_PACKAGE STREQUAL "ubuntu-20.04_x86_64")
-  add_library(SoraUnitySdk SHARED)
-
-  set(SORA_UNITY_SDK_PLATFORM Ubuntu)
 elseif (SORA_UNITY_SDK_PACKAGE STREQUAL "ubuntu-22.04_x86_64")
   add_library(SoraUnitySdk SHARED)
 
@@ -255,7 +251,7 @@ elseif (SORA_UNITY_SDK_PACKAGE STREQUAL "android")
       ${_WEBRTC_ANDROID_LDFLAGS}
   )
 
-elseif (SORA_UNITY_SDK_PACKAGE STREQUAL "ubuntu-20.04_x86_64" OR SORA_UNITY_SDK_PACKAGE STREQUAL "ubuntu-22.04_x86_64")
+elseif (SORA_UNITY_SDK_PACKAGE STREQUAL "ubuntu-22.04_x86_64")
 
   target_sources(SoraUnitySdk
     PRIVATE

--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ Please read https://github.com/shiguredo/oss/blob/master/README.en.md before use
 - Android への対応
 - Android OpenGL ES への対応
 - iOS 対応
-- Ubuntu 20.04 への対応
 - Ubuntu 22.04 への対応
 - SRTP/SRTCP の AES-GCM 対応
 - Unity のカメラ映像を取得し Sora で送信

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Please read https://github.com/shiguredo/oss/blob/master/README.en.md before use
 - Android 7 以降
 - iOS 13 以降
 - Ubuntu 22.04 x86_64
-- Ubuntu 24.04 x86_64
 
 ## 対応機能
 

--- a/run.py
+++ b/run.py
@@ -160,7 +160,7 @@ def install_deps(
             install_protobuf_args["platform"] = "win64"
         elif build_platform in ("macos_x86_64", "macos_arm64"):
             install_protobuf_args["platform"] = "osx-universal_binary"
-        elif build_platform in ("ubuntu-22.04_x86_64"):
+        elif build_platform == "ubuntu-22.04_x86_64":
             install_protobuf_args["platform"] = "linux-x86_64"
         else:
             raise Exception("Failed to install Protobuf")

--- a/run.py
+++ b/run.py
@@ -180,7 +180,7 @@ def install_deps(
             install_jsonif_args["platform"] = "darwin-amd64"
         elif build_platform == "macos_arm64":
             install_jsonif_args["platform"] = "darwin-arm64"
-        elif build_platform in ("ubuntu-22.04_x86_64"):
+        elif build_platform == "ubuntu-22.04_x86_64":
             install_jsonif_args["platform"] = "linux-amd64"
         else:
             raise Exception("Failed to install protoc-gen-jsonif")

--- a/run.py
+++ b/run.py
@@ -125,7 +125,7 @@ def install_deps(
             install_cmake_args["ext"] = "zip"
         elif build_platform in ("macos_x86_64", "macos_arm64"):
             install_cmake_args["platform"] = "macos-universal"
-        elif build_platform in ("ubuntu-20.04_x86_64", "ubuntu-22.04_x86_64"):
+        elif build_platform in ("ubuntu-22.04_x86_64"):
             install_cmake_args["platform"] = "linux-x86_64"
         else:
             raise Exception("Failed to install CMake")
@@ -160,7 +160,7 @@ def install_deps(
             install_protobuf_args["platform"] = "win64"
         elif build_platform in ("macos_x86_64", "macos_arm64"):
             install_protobuf_args["platform"] = "osx-universal_binary"
-        elif build_platform in ("ubuntu-20.04_x86_64", "ubuntu-22.04_x86_64"):
+        elif build_platform in ("ubuntu-22.04_x86_64"):
             install_protobuf_args["platform"] = "linux-x86_64"
         else:
             raise Exception("Failed to install Protobuf")
@@ -180,7 +180,7 @@ def install_deps(
             install_jsonif_args["platform"] = "darwin-amd64"
         elif build_platform == "macos_arm64":
             install_jsonif_args["platform"] = "darwin-arm64"
-        elif build_platform in ("ubuntu-20.04_x86_64", "ubuntu-22.04_x86_64"):
+        elif build_platform in ("ubuntu-22.04_x86_64"):
             install_jsonif_args["platform"] = "linux-amd64"
         else:
             raise Exception("Failed to install protoc-gen-jsonif")
@@ -209,12 +209,7 @@ def get_build_platform():
         os = release["NAME"]
         if os == "Ubuntu":
             osver = release["VERSION_ID"]
-            if osver == "20.04":
-                if arch == "x86_64":
-                    return "ubuntu-20.04_x86_64"
-                else:
-                    raise Exception("Unknown ubuntu arch")
-            elif osver == "22.04":
+            if osver == "22.04":
                 if arch == "x86_64":
                     return "ubuntu-22.04_x86_64"
                 else:
@@ -227,13 +222,18 @@ def get_build_platform():
         raise Exception(f"OS {os} not supported")
 
 
-AVAILABLE_TARGETS = ["windows_x86_64", "macos_arm64", "ubuntu-20.04_x86_64", "ubuntu-22.04_x86_64", "ios", "android"]
+AVAILABLE_TARGETS = [
+    "windows_x86_64",
+    "macos_arm64",
+    "ubuntu-22.04_x86_64",
+    "ios",
+    "android",
+]
 
 BUILD_PLATFORM = {
     "windows_x86_64": ["windows_x86_64"],
     "macos_x86_64": ["macos_x86_64", "macos_arm64", "ios"],
     "macos_arm64": ["macos_x86_64", "macos_arm64", "ios"],
-    "ubuntu-20.04_x86_64": ["ubuntu-20.04_x86_64", "android"],
     "ubuntu-22.04_x86_64": ["ubuntu-22.04_x86_64", "android"],
 }
 
@@ -352,7 +352,7 @@ def main():
             # r23b には ANDROID_CPP_FEATURES=exceptions でも例外が設定されない問題がある
             # https://github.com/android/ndk/issues/1618
             cmake_args.append("-DCMAKE_ANDROID_EXCEPTIONS=ON")
-        elif platform in ("ubuntu-20.04_x86_64", "ubuntu-22.04_x86_64"):
+        elif platform in ("ubuntu-22.04_x86_64"):
             cmake_args.append(
                 f"-DCMAKE_C_COMPILER={os.path.join(webrtc_info.clang_dir, 'bin', 'clang')}"
             )

--- a/run.py
+++ b/run.py
@@ -125,7 +125,7 @@ def install_deps(
             install_cmake_args["ext"] = "zip"
         elif build_platform in ("macos_x86_64", "macos_arm64"):
             install_cmake_args["platform"] = "macos-universal"
-        elif build_platform in ("ubuntu-22.04_x86_64"):
+        elif build_platform == "ubuntu-22.04_x86_64":
             install_cmake_args["platform"] = "linux-x86_64"
         else:
             raise Exception("Failed to install CMake")


### PR DESCRIPTION
ubuntu-20.04 をビルドから外しました。
すでにリリースバイナリは Ubuntu-20.04 はなく 22.04 のみになっており、残っていた分岐や処理を削除しました。

----
This pull request includes updates to transition the build environment from Ubuntu 20.04 to Ubuntu 22.04. The changes span across multiple configuration and build files to ensure compatibility with the new Ubuntu version.

Key changes include:

### Configuration Updates:
* Updated the `c_cpp_properties.json` file to reflect the new Ubuntu 22.04 paths for includes and builds.

### Documentation Updates:
* Modified `CHANGES.md` to document the switch from Ubuntu 20.04 to Ubuntu 22.04 for Linux x86_64 builds.
* Updated `README.md` to remove references to Ubuntu 20.04 and include Ubuntu 22.04.

### Build Script Updates:
* Removed references to Ubuntu 20.04 in `CMakeLists.txt` and ensured only Ubuntu 22.04 is used for the build platform. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL54-L57) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL258-R254)
* Updated `run.py` to remove support for Ubuntu 20.04, ensuring that dependencies are installed correctly for Ubuntu 22.04. [[1]](diffhunk://#diff-d6af0459a37d985953d7040c14f53feb3b9cc9e58b543aa3c2b80256d276c5e0L128-R128) [[2]](diffhunk://#diff-d6af0459a37d985953d7040c14f53feb3b9cc9e58b543aa3c2b80256d276c5e0L163-R163) [[3]](diffhunk://#diff-d6af0459a37d985953d7040c14f53feb3b9cc9e58b543aa3c2b80256d276c5e0L183-R183) [[4]](diffhunk://#diff-d6af0459a37d985953d7040c14f53feb3b9cc9e58b543aa3c2b80256d276c5e0L212-R212) [[5]](diffhunk://#diff-d6af0459a37d985953d7040c14f53feb3b9cc9e58b543aa3c2b80256d276c5e0L230-L236) [[6]](diffhunk://#diff-d6af0459a37d985953d7040c14f53feb3b9cc9e58b543aa3c2b80256d276c5e0L355-R355)