### PR TITLE
simulcast_request_rid 未指定の場合はフィールドも送らないようにする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,7 +25,7 @@
   - Sora 2025.2 以降で利用可能な simulcast_request_rid に対応する
   - `Sora.Config.SimulcastRequestRid` プロパティを追加する
   - `Sora.Config.SimulcastRid` を非推奨化する
-  - `simulcast_request_rid` は未指定の場合項目自体も送信しないようにする
+  - `simulcast_request_rid` は未指定の場合、項目も含めないようにする
   - @torikizi
 
 ## 2025.3.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@
   - Sora 2025.2 以降で利用可能な simulcast_request_rid に対応する
   - `Sora.Config.SimulcastRequestRid` プロパティを追加する
   - `Sora.Config.SimulcastRid` を非推奨化する
+  - `simulcast_request_rid` は未指定の場合項目自体も送信しないようにする
   - @torikizi
 
 ## 2025.3.0

--- a/SoraUnitySdkExamples/Assets/SoraUnitySdk/Sora.cs
+++ b/SoraUnitySdkExamples/Assets/SoraUnitySdk/Sora.cs
@@ -609,7 +609,10 @@ public class Sora : IDisposable
             cc.SetSimulcast(config.Simulcast.Value);
         }
         cc.simulcast_rid = config.SimulcastRid == null ? "" : config.SimulcastRid.Value.ToString().ToLower();
-        cc.simulcast_request_rid = config.SimulcastRequestRid == null ? "" : config.SimulcastRequestRid.Value.ToString().ToLower();
+        if (config.SimulcastRequestRid != null)
+        {
+            cc.SetSimulcastRequestRid(config.SimulcastRequestRid.Value.ToString().ToLower());
+        }
         cc.insecure = config.Insecure;
         cc.no_video_device = config.NoVideoDevice;
         cc.no_audio_device = config.NoAudioDevice;

--- a/proto/sora_conf_internal.proto
+++ b/proto/sora_conf_internal.proto
@@ -100,7 +100,7 @@ message ConnectConfig {
     string spotlight_unfocus_rid = 13;
     optional bool simulcast = 15;
     string simulcast_rid = 16;
-    string simulcast_request_rid = 50;
+    optional string simulcast_request_rid = 50;
     bool no_video_device = 160;
     bool no_audio_device = 161;
     CameraConfig camera_config = 17;

--- a/src/sora.cpp
+++ b/src/sora.cpp
@@ -387,7 +387,9 @@ void Sora::DoConnect(const sora_conf::internal::ConnectConfig& cc,
       config.simulcast = cc.simulcast;
     }
     config.simulcast_rid = cc.simulcast_rid;
-    config.simulcast_request_rid = cc.simulcast_request_rid;
+    if (cc.has_simulcast_request_rid()) {
+      config.simulcast_request_rid = cc.simulcast_request_rid;
+    }
     config.signaling_urls = cc.signaling_url;
     config.channel_id = cc.channel_id;
     config.client_id = cc.client_id;


### PR DESCRIPTION
simulcast_request_rid 未指定の場合はフィールドも送らないように修正