### PR TITLE
RPC リクエスト処理にタイムアウトを追加する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 /_install
 /_package
 *.swp
+.DS_Store
+/SoraUnitySdk/
+/SoraUnitySdk.zip

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,10 +30,10 @@
   - @torikizi
 - [ADD] RPC 機能を追加する
   - Sora 2025.2 以降で利用可能な RPC 機能に対応する
-  - `Sora.SendRpcNotification()` メソッドを追加する
+  - `Sora.RequestRpcNotification()` メソッドを追加する
     - JSON-RPC 2.0 の通知 (Notification) を送信する
     - Sora からのレスポンスは返らない
-  - `Sora.SendRpcMessage()` メソッドを追加する
+  - `Sora.RequestRpc()` メソッドを追加する
     - JSON-RPC 2.0 のリクエスト (Request) を送信する
     - レスポンスが返ってくるまでのタイムアウトを `timeoutMillis` でミリ秒単位で指定できる
       - 指定しない場合はデフォルトの 5,000ms となる

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,15 +30,16 @@
   - @torikizi
 - [ADD] RPC 機能を追加する
   - Sora 2025.2 以降で利用可能な RPC 機能に対応する
-  - `Sora.OnRpc` コールバックを追加する
-  - `Sora.RequestRpcNotification()` メソッドを追加する
+  - `Sora.SendRpcNotification()` メソッドを追加する
     - JSON-RPC 2.0 の通知 (Notification) を送信する
     - Sora からのレスポンスは返らない
-  - `Sora.RequestRpc()` メソッドを追加する
+  - `Sora.SendRpcMessage()` メソッドを追加する
     - JSON-RPC 2.0 のリクエスト (Request) を送信する
-    - `id` に数値または文字列を指定する
-    - Sora からのレスポンスは `OnRpc` コールバックで受け取る
+    - レスポンスが返ってくるまでのタイムアウトを `timeoutMillis` でミリ秒単位で指定できる
+      - 指定しない場合はデフォルトの 5,000ms となる
+    - Sora からのレスポンスは引数で渡す `RpcResult` コールバックで受け取る
   - @torikizi
+  - @t-miya
 
 ### misc
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ Please read <https://github.com/shiguredo/oss/blob/master/README.en.md> before u
 
 [WebRTC SFU Sora Unity SDK サンプル集](./SoraUnitySdkExamples)
 
+## ソースコードディレクトリ構成
+
+- `src/` : ネイティブプラグイン（Unity 向けラッパー）の SDK 実装です
+- `SoraUnitySdkExamples/` : Unity サンプルプロジェクトです
+- `SoraUnitySdkExamples/Assets/SoraUnitySdk/` : Unity 向けの C# での SDK 実装です
+
 ### サンプル動作例
 
 - [「こんな感じに Unity のカメラ映像を WebRTC で配信できるようになりました https://t\.co/R98ZmZTFOK」 / Twitter](https://twitter.com/melponn/status/1193406538494275592)

--- a/SoraUnitySdkExamples/Assets/SoraSample.cs
+++ b/SoraUnitySdkExamples/Assets/SoraSample.cs
@@ -1218,7 +1218,7 @@ public class SoraSample : MonoBehaviour
         }
     }
 
-    void RequestRpc(string method, string paramsJson)
+    void RequestRpcWithInspectorSettings(string method, string paramsJson)
     {
         if (sora == null)
         {
@@ -1258,7 +1258,7 @@ public class SoraSample : MonoBehaviour
         {
             paramsJson = $"{{\"sender_connection_id\":\"{sendRequestSimulcastRidSenderConnectionId}\",\"rid\":\"{sendRequestSimulcastRid}\"}}";
         }
-        RequestRpc("2025.2.0/RequestSimulcastRid", paramsJson);
+        RequestRpcWithInspectorSettings("2025.2.0/RequestSimulcastRid", paramsJson);
     }
 
     void SendRequestSpotlightRid()
@@ -1273,7 +1273,7 @@ public class SoraSample : MonoBehaviour
         {
             paramsJson = $"{{\"send_connection_id\":\"{sendRequestSpotlightRidConnectionId}\",\"spotlight_focus_rid\":\"{sendRequestSpotlightFocusRid}\",\"spotlight_unfocus_rid\":\"{sendRequestSpotlightUnfocusRid}\"}}";
         }
-        RequestRpc("2025.2.0/RequestSpotlightRid", paramsJson);
+        RequestRpcWithInspectorSettings("2025.2.0/RequestSpotlightRid", paramsJson);
     }
 
     void SendResetSpotlightRid()
@@ -1288,7 +1288,7 @@ public class SoraSample : MonoBehaviour
         {
             paramsJson = $"{{\"send_connection_id\":\"{sendResetSpotlightRidConnectionId}\"}}";
         }
-        RequestRpc("2025.2.0/ResetSpotlightRid", paramsJson);
+        RequestRpcWithInspectorSettings("2025.2.0/ResetSpotlightRid", paramsJson);
     }
 
     void SendPutSignalingNotifyMetadata()
@@ -1297,7 +1297,7 @@ public class SoraSample : MonoBehaviour
         string paramsJson = sendPutSignalingNotifyMetadataPush
             ? $"{{\"push\":true,\"metadata\":{sendPutSignalingNotifyMetadataJson}}}"
             : $"{{\"metadata\":{sendPutSignalingNotifyMetadataJson}}}";
-        RequestRpc("2025.2.0/PutSignalingNotifyMetadata", paramsJson);
+        RequestRpcWithInspectorSettings("2025.2.0/PutSignalingNotifyMetadata", paramsJson);
     }
 
     void SendPutSignalingNotifyMetadataItem()
@@ -1306,7 +1306,7 @@ public class SoraSample : MonoBehaviour
         string paramsJson = sendPutSignalingNotifyMetadataItemPush
             ? $"{{\"push\":true,\"key\":\"{sendPutSignalingNotifyMetadataItemKey}\",\"value\":{sendPutSignalingNotifyMetadataItemValue}}}"
             : $"{{\"key\":\"{sendPutSignalingNotifyMetadataItemKey}\",\"value\":{sendPutSignalingNotifyMetadataItemValue}}}";
-        RequestRpc("2025.2.0/PutSignalingNotifyMetadataItem", paramsJson);
+        RequestRpcWithInspectorSettings("2025.2.0/PutSignalingNotifyMetadataItem", paramsJson);
     }
 
     public void OnClickVideoMute()

--- a/SoraUnitySdkExamples/Assets/SoraSample.cs
+++ b/SoraUnitySdkExamples/Assets/SoraSample.cs
@@ -223,7 +223,11 @@ public class SoraSample : MonoBehaviour
 
     [Header("RPC メッセージの設定")]
     public RpcMessageType rpcMessageType = RpcMessageType.None;
-    int rpcRequestIdCounter = 0;
+
+    [Header("RPC タイムアウトの設定")]
+    // 空欄の場合は SDK のデフォルトタイムアウトを利用する
+    // 指定する場合はミリ秒の数値を入れる
+    public string rpcTimeoutMillis = "";
 
     [Header("RequestSimulcastRid の設定")]
     public string sendRequestSimulcastRid = "r0";
@@ -705,23 +709,6 @@ public class SoraSample : MonoBehaviour
         {
             Debug.LogFormat("OnPush: {0}", json);
         };
-        sora.OnRpc = (json) =>
-        {
-            Debug.LogFormat("OnRpc: {0}", json);
-
-            // JSON-RPC 2.0 レスポンスをパースして処理する例
-            // 実際には JSON パーサーを使用してください
-            if (json.Contains("\"result\""))
-            {
-                // 成功レスポンスの処理
-                Debug.Log("RPC request succeeded");
-            }
-            else if (json.Contains("\"error\""))
-            {
-                // エラーレスポンスの処理
-                Debug.LogError("RPC request failed");
-            }
-        };
         // これは別スレッドからやってくるので注意すること
         sora.OnHandleAudio = (buf, samples, channels) =>
         {
@@ -1178,6 +1165,12 @@ public class SoraSample : MonoBehaviour
         }
     }
 
+    [ContextMenu("RPC を送信する")]
+    void SendRpcFromInspector()
+    {
+        OnClickSendRpc();
+    }
+
     public void OnClickSendRpc()
     {
         if (sora == null)
@@ -1209,16 +1202,53 @@ public class SoraSample : MonoBehaviour
         }
     }
 
-    // RPC リクエストごとに一意な ID を生成する
-    int GenerateRpcId()
+    void HandleRpcResult(Sora.RpcResult result)
     {
-        return ++rpcRequestIdCounter;
+        switch (result.ResultKind)
+        {
+            case Sora.RpcResultKind.ResponseReceived:
+                Debug.LogFormat("RPC response: method={0}, response={1}", result.Method, result.ResponseJson);
+                break;
+            case Sora.RpcResultKind.Timeout:
+                Debug.LogErrorFormat("RPC timeout: method={0}", result.Method);
+                break;
+            case Sora.RpcResultKind.Canceled:
+                Debug.LogWarningFormat("RPC canceled: method={0}", result.Method);
+                break;
+        }
+    }
+
+    void SendRpcMessage(string method, string paramsJson)
+    {
+        if (sora == null)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(rpcTimeoutMillis))
+        {
+            sora.SendRpcMessage(method, paramsJson, HandleRpcResult);
+            return;
+        }
+
+        var timeoutMillisText = rpcTimeoutMillis.Trim();
+        if (!long.TryParse(timeoutMillisText, out var timeoutMillis))
+        {
+            Debug.LogErrorFormat("RPC timeoutMillis の形式が不正です: timeoutMillis={0}", rpcTimeoutMillis);
+            return;
+        }
+        if (timeoutMillis <= 0)
+        {
+            Debug.LogErrorFormat("RPC timeoutMillis は 1 以上を指定してください: timeoutMillis={0}", timeoutMillis);
+            return;
+        }
+
+        sora.SendRpcMessage(method, paramsJson, HandleRpcResult, timeoutMillis);
     }
 
     void SendRequestSimulcastRid()
     {
-        int id = GenerateRpcId();
-        Debug.LogFormat("SendRequestSimulcastRid: rid={0}, sender_connection_id={1}, id={2}", sendRequestSimulcastRid, sendRequestSimulcastRidSenderConnectionId, id);
+        Debug.LogFormat("SendRequestSimulcastRid: rid={0}, sender_connection_id={1}", sendRequestSimulcastRid, sendRequestSimulcastRidSenderConnectionId);
         string paramsJson;
         if (string.IsNullOrEmpty(sendRequestSimulcastRidSenderConnectionId))
         {
@@ -1228,13 +1258,12 @@ public class SoraSample : MonoBehaviour
         {
             paramsJson = $"{{\"sender_connection_id\":\"{sendRequestSimulcastRidSenderConnectionId}\",\"rid\":\"{sendRequestSimulcastRid}\"}}";
         }
-        sora.RequestRpc("2025.2.0/RequestSimulcastRid", paramsJson, id);
+        SendRpcMessage("2025.2.0/RequestSimulcastRid", paramsJson);
     }
 
     void SendRequestSpotlightRid()
     {
-        int id = GenerateRpcId();
-        Debug.LogFormat("SendRequestSpotlightRid: focus={0}, unfocus={1}, send_connection_id={2}, id={3}", sendRequestSpotlightFocusRid, sendRequestSpotlightUnfocusRid, sendRequestSpotlightRidConnectionId, id);
+        Debug.LogFormat("SendRequestSpotlightRid: focus={0}, unfocus={1}, send_connection_id={2}", sendRequestSpotlightFocusRid, sendRequestSpotlightUnfocusRid, sendRequestSpotlightRidConnectionId);
         string paramsJson;
         if (string.IsNullOrEmpty(sendRequestSpotlightRidConnectionId))
         {
@@ -1244,13 +1273,12 @@ public class SoraSample : MonoBehaviour
         {
             paramsJson = $"{{\"send_connection_id\":\"{sendRequestSpotlightRidConnectionId}\",\"spotlight_focus_rid\":\"{sendRequestSpotlightFocusRid}\",\"spotlight_unfocus_rid\":\"{sendRequestSpotlightUnfocusRid}\"}}";
         }
-        sora.RequestRpc("2025.2.0/RequestSpotlightRid", paramsJson, id);
+        SendRpcMessage("2025.2.0/RequestSpotlightRid", paramsJson);
     }
 
     void SendResetSpotlightRid()
     {
-        int id = GenerateRpcId();
-        Debug.LogFormat("SendResetSpotlightRid: send_connection_id={0}, id={1}", sendResetSpotlightRidConnectionId, id);
+        Debug.LogFormat("SendResetSpotlightRid: send_connection_id={0}", sendResetSpotlightRidConnectionId);
         string paramsJson;
         if (string.IsNullOrEmpty(sendResetSpotlightRidConnectionId))
         {
@@ -1260,27 +1288,25 @@ public class SoraSample : MonoBehaviour
         {
             paramsJson = $"{{\"send_connection_id\":\"{sendResetSpotlightRidConnectionId}\"}}";
         }
-        sora.RequestRpc("2025.2.0/ResetSpotlightRid", paramsJson, id);
+        SendRpcMessage("2025.2.0/ResetSpotlightRid", paramsJson);
     }
 
     void SendPutSignalingNotifyMetadata()
     {
-        int id = GenerateRpcId();
-        Debug.LogFormat("SendPutSignalingNotifyMetadata: {0}, id={1}", sendPutSignalingNotifyMetadataJson, id);
+        Debug.LogFormat("SendPutSignalingNotifyMetadata: {0}", sendPutSignalingNotifyMetadataJson);
         string paramsJson = sendPutSignalingNotifyMetadataPush
             ? $"{{\"push\":true,\"metadata\":{sendPutSignalingNotifyMetadataJson}}}"
             : $"{{\"metadata\":{sendPutSignalingNotifyMetadataJson}}}";
-        sora.RequestRpc("2025.2.0/PutSignalingNotifyMetadata", paramsJson, id);
+        SendRpcMessage("2025.2.0/PutSignalingNotifyMetadata", paramsJson);
     }
 
     void SendPutSignalingNotifyMetadataItem()
     {
-        int id = GenerateRpcId();
-        Debug.LogFormat("SendPutSignalingNotifyMetadataItem: key={0}, value={1}, id={2}", sendPutSignalingNotifyMetadataItemKey, sendPutSignalingNotifyMetadataItemValue, id);
+        Debug.LogFormat("SendPutSignalingNotifyMetadataItem: key={0}, value={1}", sendPutSignalingNotifyMetadataItemKey, sendPutSignalingNotifyMetadataItemValue);
         string paramsJson = sendPutSignalingNotifyMetadataItemPush
             ? $"{{\"push\":true,\"key\":\"{sendPutSignalingNotifyMetadataItemKey}\",\"value\":{sendPutSignalingNotifyMetadataItemValue}}}"
             : $"{{\"key\":\"{sendPutSignalingNotifyMetadataItemKey}\",\"value\":{sendPutSignalingNotifyMetadataItemValue}}}";
-        sora.RequestRpc("2025.2.0/PutSignalingNotifyMetadataItem", paramsJson, id);
+        SendRpcMessage("2025.2.0/PutSignalingNotifyMetadataItem", paramsJson);
     }
 
     public void OnClickVideoMute()

--- a/SoraUnitySdkExamples/Assets/SoraSample.cs
+++ b/SoraUnitySdkExamples/Assets/SoraSample.cs
@@ -1166,7 +1166,7 @@ public class SoraSample : MonoBehaviour
     }
 
     [ContextMenu("RPC を送信する")]
-    void SendRpcFromInspector()
+    void SendRpcFromContextMenu()
     {
         OnClickSendRpc();
     }

--- a/SoraUnitySdkExamples/Assets/SoraSample.cs
+++ b/SoraUnitySdkExamples/Assets/SoraSample.cs
@@ -1218,7 +1218,7 @@ public class SoraSample : MonoBehaviour
         }
     }
 
-    void SendRpcMessage(string method, string paramsJson)
+    void RequestRpc(string method, string paramsJson)
     {
         if (sora == null)
         {
@@ -1227,7 +1227,7 @@ public class SoraSample : MonoBehaviour
 
         if (string.IsNullOrWhiteSpace(rpcTimeoutMillis))
         {
-            sora.SendRpcMessage(method, paramsJson, HandleRpcResult);
+            sora.RequestRpc(method, paramsJson, HandleRpcResult);
             return;
         }
 
@@ -1243,7 +1243,7 @@ public class SoraSample : MonoBehaviour
             return;
         }
 
-        sora.SendRpcMessage(method, paramsJson, HandleRpcResult, timeoutMillis);
+        sora.RequestRpc(method, paramsJson, HandleRpcResult, timeoutMillis);
     }
 
     void SendRequestSimulcastRid()
@@ -1258,7 +1258,7 @@ public class SoraSample : MonoBehaviour
         {
             paramsJson = $"{{\"sender_connection_id\":\"{sendRequestSimulcastRidSenderConnectionId}\",\"rid\":\"{sendRequestSimulcastRid}\"}}";
         }
-        SendRpcMessage("2025.2.0/RequestSimulcastRid", paramsJson);
+        RequestRpc("2025.2.0/RequestSimulcastRid", paramsJson);
     }
 
     void SendRequestSpotlightRid()
@@ -1273,7 +1273,7 @@ public class SoraSample : MonoBehaviour
         {
             paramsJson = $"{{\"send_connection_id\":\"{sendRequestSpotlightRidConnectionId}\",\"spotlight_focus_rid\":\"{sendRequestSpotlightFocusRid}\",\"spotlight_unfocus_rid\":\"{sendRequestSpotlightUnfocusRid}\"}}";
         }
-        SendRpcMessage("2025.2.0/RequestSpotlightRid", paramsJson);
+        RequestRpc("2025.2.0/RequestSpotlightRid", paramsJson);
     }
 
     void SendResetSpotlightRid()
@@ -1288,7 +1288,7 @@ public class SoraSample : MonoBehaviour
         {
             paramsJson = $"{{\"send_connection_id\":\"{sendResetSpotlightRidConnectionId}\"}}";
         }
-        SendRpcMessage("2025.2.0/ResetSpotlightRid", paramsJson);
+        RequestRpc("2025.2.0/ResetSpotlightRid", paramsJson);
     }
 
     void SendPutSignalingNotifyMetadata()
@@ -1297,7 +1297,7 @@ public class SoraSample : MonoBehaviour
         string paramsJson = sendPutSignalingNotifyMetadataPush
             ? $"{{\"push\":true,\"metadata\":{sendPutSignalingNotifyMetadataJson}}}"
             : $"{{\"metadata\":{sendPutSignalingNotifyMetadataJson}}}";
-        SendRpcMessage("2025.2.0/PutSignalingNotifyMetadata", paramsJson);
+        RequestRpc("2025.2.0/PutSignalingNotifyMetadata", paramsJson);
     }
 
     void SendPutSignalingNotifyMetadataItem()
@@ -1306,7 +1306,7 @@ public class SoraSample : MonoBehaviour
         string paramsJson = sendPutSignalingNotifyMetadataItemPush
             ? $"{{\"push\":true,\"key\":\"{sendPutSignalingNotifyMetadataItemKey}\",\"value\":{sendPutSignalingNotifyMetadataItemValue}}}"
             : $"{{\"key\":\"{sendPutSignalingNotifyMetadataItemKey}\",\"value\":{sendPutSignalingNotifyMetadataItemValue}}}";
-        SendRpcMessage("2025.2.0/PutSignalingNotifyMetadataItem", paramsJson);
+        RequestRpc("2025.2.0/PutSignalingNotifyMetadataItem", paramsJson);
     }
 
     public void OnClickVideoMute()

--- a/SoraUnitySdkExamples/Assets/SoraUnitySdk/Sora.cs
+++ b/SoraUnitySdkExamples/Assets/SoraUnitySdk/Sora.cs
@@ -1472,6 +1472,10 @@ public class Sora : IDisposable
     /// OnAddTrack や OnRemoveTrack, OnDisconnect といったコールバックは、一部を除き、この関数を呼び出すことで発生します。
     /// そのため、この関数は Update() などの定期的に実行される場所で呼び出すようにして下さい。
     ///
+    /// RPC のレスポンス受信もこの関数の呼び出しで処理されます。
+    /// ネイティブからの RPC レスポンス到達自体は Unity スレッドとは別のスレッドで発生する可能性がありますが、
+    /// 内部でキューに積み、DispatchEvents() 内で Unity スレッド上の処理に寄せています。
+    ///
     /// 例外として、OnHandleAudio と OnCapturerFrame はこの関数を呼ばなくても発生しますが、
     /// Unity スレッドとは別のスレッドから呼び出されるため同期に注意する必要があります。
     /// </remarks>

--- a/SoraUnitySdkExamples/Assets/SoraUnitySdk/Sora.cs
+++ b/SoraUnitySdkExamples/Assets/SoraUnitySdk/Sora.cs
@@ -546,7 +546,7 @@ public class Sora : IDisposable
         public string Method;
         // リクエストパラメータ Json 文字列
         public string ParamsJson;
-        // RPC レスポンス用のコードバック
+        // RPC レスポンス用のコールバック
         public Action<RpcResult> OnResult;
 
         public PendingRpc(long deadlineMillis, string method, string paramsJson, Action<RpcResult> onResult)
@@ -1375,7 +1375,7 @@ public class Sora : IDisposable
                 var timeoutIds = new List<long>();
                 foreach (var kv in pendingRpcRequests)
                 {
-                    // タイムアウト時間を過ぎていか判定し、タイムアウト対象IDリストに追加します
+                    // タイムアウト時間を過ぎているか判定し、タイムアウト対象IDリストに追加します
                     if (nowMillis >= kv.Value.DeadlineMillis)
                     {
                         timeoutIds.Add(kv.Key);

--- a/SoraUnitySdkExamples/Assets/SoraUnitySdk/Sora.cs
+++ b/SoraUnitySdkExamples/Assets/SoraUnitySdk/Sora.cs
@@ -574,6 +574,7 @@ public class Sora : IDisposable
     /// </summary>
     /// <remarks>
     /// Unity スレッド上で実行するようにしてください。
+    /// onResult などのコールバック内から Dispose() を呼び出すと、破棄処理が再入するため避けてください。
     /// 既に Connect() を呼び出している場合、この関数を呼び出す前に、OnDisconnect コールバックが呼ばれていることを確認して下さい。
     /// OnDisconnect コールバックが呼ばれる前に Dispose() を呼び出した場合の動作は未定義です。
     /// </remarks>

--- a/SoraUnitySdkExamples/Assets/SoraUnitySdk/Sora.cs
+++ b/SoraUnitySdkExamples/Assets/SoraUnitySdk/Sora.cs
@@ -1584,7 +1584,7 @@ public class Sora : IDisposable
     }
 
     // JSON-RPC 2.0 メッセージを送信します。
-    void SendRpcRawMessage(string rpcMessage)
+    void SendRpcMessage(string rpcMessage)
     {
         var bytes = System.Text.Encoding.UTF8.GetBytes(rpcMessage);
         sora_send_message(p, "rpc", bytes, bytes.Length);
@@ -1659,7 +1659,7 @@ public class Sora : IDisposable
 
         var methodJson = EscapeJsonString(method);
         var rpcMessage = $"{{\"jsonrpc\":\"2.0\",\"method\":{methodJson},\"params\":{paramsJson}}}";
-        SendRpcRawMessage(rpcMessage);
+        SendRpcMessage(rpcMessage);
     }
 
     /// <summary>
@@ -1725,7 +1725,7 @@ public class Sora : IDisposable
 
         var methodJson = EscapeJsonString(method);
         var rpcMessage = $"{{\"jsonrpc\":\"2.0\",\"method\":{methodJson},\"params\":{paramsJson},\"id\":{id}}}";
-        SendRpcRawMessage(rpcMessage);
+        SendRpcMessage(rpcMessage);
     }
 
     private delegate void DeviceEnumCallbackDelegate(string device_name, string unique_name, IntPtr userdata);

--- a/SoraUnitySdkExamples/Assets/SoraUnitySdk/Sora.cs
+++ b/SoraUnitySdkExamples/Assets/SoraUnitySdk/Sora.cs
@@ -1365,6 +1365,15 @@ public class Sora : IDisposable
                 responseJson));
         }
 
+        // レスポンス待ちリクエストがなければ抜けます
+        lock (rpcLock)
+        {
+            if (pendingRpcRequests.Count == 0)
+            {
+                return;
+            }
+        }
+
         // レスポンス待ちリクエストのタイムアウト処理を行います
         List<PendingRpc> timeoutTargets = new List<PendingRpc>();
         var nowMillis = GetNowMillis();

--- a/SoraUnitySdkExamples/Assets/SoraUnitySdk/Sora.cs
+++ b/SoraUnitySdkExamples/Assets/SoraUnitySdk/Sora.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using UnityEngine;
 
@@ -492,7 +493,6 @@ public class Sora : IDisposable
     Action<string>? onNotify;
     Action<string>? onPush;
     Action<string, byte[]>? onMessage;
-    Action<string>? onRpc;
     Action<SoraConf.ErrorCode, string>? onDisconnect;
     Action<string>? onDataChannel;
     Action<short[], int, int>? onHandleAudio;
@@ -500,15 +500,92 @@ public class Sora : IDisposable
     UnityEngine.Rendering.CommandBuffer commandBuffer;
     UnityEngine.Camera? unityCamera;
 
+    // RPC リクエスト結果 Enum
+    public enum RpcResultKind
+    {
+        // レスポンスを受信しました（result と error の判別は行いません）
+        ResponseReceived,
+        // タイムアウトしました
+        Timeout,
+        // 破棄や切断によりキャンセルされました
+        Canceled,
+    }
+    // RPC レスポンスの構造体
+    public readonly struct RpcResult
+    {
+        public readonly RpcResultKind ResultKind;
+        // リクエストした RPC メソッド
+        public readonly string Method;
+        // リクエストパラメータ Json 文字列
+        public readonly string ParamsJson;
+        // レスポンス Json 文字列。データ内容のパースは SDK の利用者側の責務となります
+        public readonly string? ResponseJson;
+
+        public RpcResult(
+            RpcResultKind resultKind,
+            string method,
+            string paramsJson,
+            string? responseJson)
+        {
+            ResultKind = resultKind;
+            Method = method;
+            ParamsJson = paramsJson;
+            ResponseJson = responseJson;
+        }
+    }
+
+    // RPC リクエスト後にレスポンスを待つタイムアウト時間のデフォルト
+    const long DefaultRpcTimeoutMillis = 5000;
+
+    // 非同期で実行された RPC リクエストがレスポンスを待っている間に保持される情報の構造体
+    struct PendingRpc
+    {
+        // タイムアウト用の期限
+        public long DeadlineMillis;
+        // リクエストされた RPC メソッド
+        public string Method;
+        // リクエストパラメータ Json 文字列
+        public string ParamsJson;
+        // RPC レスポンス用のコードバック
+        public Action<RpcResult> OnResult;
+
+        public PendingRpc(long deadlineMillis, string method, string paramsJson, Action<RpcResult> onResult)
+        {
+            DeadlineMillis = deadlineMillis;
+            Method = method;
+            ParamsJson = paramsJson;
+            OnResult = onResult;
+        }
+    }
+
+    // RPC レスポンスキュー、ID 採番等の RPC に関する共有データを排他制御するためのロック
+    readonly object rpcLock = new object();
+    // RPC レスポンスを Unity スレッド上で順番に処理するためのキュー
+    readonly Queue<string> rpcResponseJsonQueue = new Queue<string>();
+    // RPC リクエスト送信済みでレスポンス待ちになっているリクエストを保持する辞書。リクエスト ID をキーとします
+    readonly Dictionary<long, PendingRpc> pendingRpcRequests = new Dictionary<long, PendingRpc>();
+    // RPC リクエスト ID
+    // リクエストとレスポンスコンテキストの紐付けに利用されますが、 
+    // `pendingRpcRequests` のキーとしても利用されます。重複を防ぐため自動採番としています。
+    long nextRpcRequestId = 1;
+
     /// <summary>
     /// Sora オブジェクトを破棄します。
     /// </summary>
     /// <remarks>
+    /// Unity スレッド上で実行するようにしてください。
     /// 既に Connect() を呼び出している場合、この関数を呼び出す前に、OnDisconnect コールバックが呼ばれていることを確認して下さい。
     /// OnDisconnect コールバックが呼ばれる前に Dispose() を呼び出した場合の動作は未定義です。
     /// </remarks>
     public void Dispose()
     {
+        // レスポンス待ちになっている RPC リクエストを全てキャンセルする
+        CancelAllPendingRpc();
+        lock (rpcLock)
+        {
+            rpcResponseJsonQueue.Clear();
+        }
+
         if (p != IntPtr.Zero)
         {
             sora_destroy(p);
@@ -539,6 +616,7 @@ public class Sora : IDisposable
         p = sora_create();
         selfHandle = GCHandle.Alloc(this);
         commandBuffer = new UnityEngine.Rendering.CommandBuffer();
+        sora_set_on_rpc(p, RpcCallback, GCHandle.ToIntPtr(selfHandle));
     }
 
     /// <summary>
@@ -1188,15 +1266,164 @@ public class Sora : IDisposable
     static private void RpcCallback(string json, IntPtr userdata)
     {
         var sora = GCHandle.FromIntPtr(userdata).Target as Sora;
-        sora!.onRpc!(json);
+        sora!.EnqueueRpcResponseJson(json);
     }
 
-    public Action<string>? OnRpc
+    // RPC リクエストタイムアウト時間算出のための基準時間を生成
+    static readonly Stopwatch nowStopwatch = Stopwatch.StartNew();
+
+    // nowStopwatch からの経過時間をミリ秒取得します。
+    // この値と指定タイムアウト秒数からタイムアウト時間を算出します。
+    static long GetNowMillis()
     {
-        set
+        return nowStopwatch.ElapsedMilliseconds;
+    }
+
+    void EnqueueRpcResponseJson(string json)
+    {
+        lock (rpcLock)
         {
-            onRpc = value;
-            sora_set_on_rpc(p, value == null ? null : RpcCallback, GCHandle.ToIntPtr(selfHandle));
+            rpcResponseJsonQueue.Enqueue(json);
+        }
+    }
+
+    // レスポンス待ちの全ての RPC リクエストをキャンセルします。
+    // Dispose で呼び出されます。
+    void CancelAllPendingRpc()
+    {
+        List<PendingRpc> cancelTargets;
+        lock (rpcLock)
+        {
+            if (pendingRpcRequests.Count == 0)
+            {
+                return;
+            }
+            cancelTargets = new List<PendingRpc>(pendingRpcRequests.Values);
+            pendingRpcRequests.Clear();
+        }
+
+        // キャンセル扱いで結果をコールバックで返します
+        foreach (var pending in cancelTargets)
+        {
+            pending.OnResult(new RpcResult(
+                RpcResultKind.Canceled,
+                pending.Method,
+                pending.ParamsJson,
+                null));
+        }
+    }
+
+    // RPC レスポンスハンドリング
+    // DispatchEvents() から呼ばれる前提で、必ず Unity スレッドで実行されます。
+    // ネイティブから RPC レスポンスが別スレッドで来た場合は、キューに積まれたものをここで処理します。
+    void HandleRpcInternal()
+    {
+        while (true)
+        {
+            string? responseJson = null;
+            lock (rpcLock)
+            {
+                // キューから1つずつ取り出して処理します
+                if (rpcResponseJsonQueue.Count != 0)
+                {
+                    responseJson = rpcResponseJsonQueue.Dequeue();
+                }
+            }
+
+            // Dequeue できなかった場合はキューが空となっているため抜けます
+            if (responseJson == null)
+            {
+                break;
+            }
+
+            // レスポンスデータの JSON 文字列から、リクエスト ID のみを抜き出します。
+            // ID が取得できない場合はレスポンス待ちと紐付けできないため捨てます。
+            var id = JsonRpcUtil.ParseId(responseJson);
+            if (id == 0)
+            {
+                continue;
+            }
+
+            PendingRpc pending;
+            lock (rpcLock)
+            {
+                // レスポンス待ち辞書からリクエスト ID で抽出し、処理済みとして除去します。
+                // 辞書内に見つからない場合は既にレスポンスを返しているとみなし何もしません。
+                if (!pendingRpcRequests.TryGetValue(id, out pending))
+                {
+                    continue;
+                }
+                pendingRpcRequests.Remove(id);
+            }
+
+            // RPC 結果をコールバックで返します
+            pending.OnResult(new RpcResult(
+                RpcResultKind.ResponseReceived,
+                pending.Method,
+                pending.ParamsJson,
+                responseJson));
+        }
+
+        // レスポンス待ちリクエストのタイムアウト処理を行います
+        List<PendingRpc> timeoutTargets = new List<PendingRpc>();
+        var nowMillis = GetNowMillis();
+        lock (rpcLock)
+        {
+            if (pendingRpcRequests.Count != 0)
+            {
+                var timeoutIds = new List<long>();
+                foreach (var kv in pendingRpcRequests)
+                {
+                    // タイムアウト時間を過ぎていか判定し、タイムアウト対象IDリストに追加します
+                    if (nowMillis >= kv.Value.DeadlineMillis)
+                    {
+                        timeoutIds.Add(kv.Key);
+                    }
+                }
+                // タイムアウトターゲットリストの作成とレスポンス待ちリクエストリストからの除去を行います
+                foreach (var id in timeoutIds)
+                {
+                    timeoutTargets.Add(pendingRpcRequests[id]);
+                    pendingRpcRequests.Remove(id);
+                }
+            }
+        }
+
+        // タイムアウトとなったリクエストを Timeout でコールバックとして返します
+        foreach (var pending in timeoutTargets)
+        {
+            pending.OnResult(new RpcResult(
+                RpcResultKind.Timeout,
+                pending.Method,
+                pending.ParamsJson,
+                null));
+        }
+    }
+
+    // RPC レスポンスの JSON 文字列から ID のみを抽出するための Serializable クラス
+    [Serializable]
+    class JsonRpcResponseIdOnly
+    {
+        public string jsonrpc = "";
+        // サーバーが数値 id を返す前提
+        public long id;
+    }
+
+    static class JsonRpcUtil
+    {
+        // JsonRpcUtil 経由での関数呼び出しとすることでデータ型にパース手段が生えない設計にしています。
+        // ID が取得できない場合はエラーを握りつぶし 0 を返します。
+        // レスポンス待ちと紐付けできないため呼び出し元で捨てられます。
+        public static long ParseId(string json)
+        {
+            try
+            {
+                return JsonUtility.FromJson<JsonRpcResponseIdOnly>(json).id;
+            }
+            catch (Exception)
+            {
+                return 0;
+            }
         }
     }
 
@@ -1206,6 +1433,7 @@ public class Sora : IDisposable
     static private void DisconnectCallback(int errorCode, string message, IntPtr userdata)
     {
         var sora = GCHandle.FromIntPtr(userdata).Target as Sora;
+        sora!.CancelAllPendingRpc();
         sora!.onDisconnect!((SoraConf.ErrorCode)errorCode, message);
     }
 
@@ -1249,6 +1477,7 @@ public class Sora : IDisposable
     public void DispatchEvents()
     {
         sora_dispatch_events(p);
+        HandleRpcInternal();
     }
 
     /// <summary>
@@ -1350,7 +1579,7 @@ public class Sora : IDisposable
     }
 
     // JSON-RPC 2.0 メッセージを送信します。
-    void SendRpcMessage(string rpcMessage)
+    void SendRpcRawMessage(string rpcMessage)
     {
         var bytes = System.Text.Encoding.UTF8.GetBytes(rpcMessage);
         sora_send_message(p, "rpc", bytes, bytes.Length);
@@ -1412,48 +1641,86 @@ public class Sora : IDisposable
     /// </remarks>
     /// <param name="method">呼び出すメソッド名</param>
     /// <param name="paramsJson">メソッドのパラメータを表す JSON 文字列。オブジェクト形式 (例: {"key":"value"}) または配列形式 (例: [1,2,3]) で指定します。パラメータがない場合は "{}" を指定してください</param>
-    public void RequestRpcNotification(string method, string paramsJson)
+    public void SendRpcNotification(string method, string paramsJson)
     {
+        if (method == null)
+        {
+            throw new ArgumentNullException(nameof(method));
+        }
+        if (paramsJson == null)
+        {
+            throw new ArgumentNullException(nameof(paramsJson));
+        }
+
         var methodJson = EscapeJsonString(method);
         var rpcMessage = $"{{\"jsonrpc\":\"2.0\",\"method\":{methodJson},\"params\":{paramsJson}}}";
-        SendRpcMessage(rpcMessage);
+        SendRpcRawMessage(rpcMessage);
     }
 
-    void RequestRpcInternal(string method, string paramsJson, string idJson)
+    /// <summary>
+    /// JSON-RPC 2.0 メッセージを送信します。
+    /// </summary>
+    /// <remarks>
+    /// Sora への送信後、レスポンスが返ってくるまでのタイムアウト時間は 5,000 ms です。
+    /// レスポンス受信とタイムアウト判定は DispatchEvents() の呼び出しで処理されます。
+    /// DispatchEvents() を定期的に呼び出さない場合、onResult は呼ばれず、タイムアウトも返りません。
+    /// ResultKind は成功 / 失敗を表しません。 ResponseJson の内容を利用者側で判定してください。
+    /// </remarks>
+    /// <param name="method">呼び出すメソッド名</param>
+    /// <param name="paramsJson">メソッドのパラメータを表す JSON 文字列。オブジェクト形式 (例: {"key":"value"}) または配列形式 (例: [1,2,3]) で指定します。パラメータがない場合は "{}" を指定してください</param>
+    /// <param name="onResult">Sora レスポンス用のコールバック</param>
+    public void SendRpcMessage(string method, string paramsJson, Action<RpcResult> onResult)
     {
+        SendRpcMessage(method, paramsJson, onResult, DefaultRpcTimeoutMillis);
+    }
+
+    /// <summary>
+    /// JSON-RPC 2.0 メッセージを送信します。
+    /// </summary>
+    /// <remarks>
+    /// レスポンス受信とタイムアウト判定は DispatchEvents() の呼び出しで処理されます。
+    /// DispatchEvents() を定期的に呼び出さない場合、onResult は呼ばれず、タイムアウトも返りません。
+    /// ResultKind は成功 / 失敗を表しません。 ResponseJson の内容を利用者側で判定してください。
+    /// </remarks>
+    /// <param name="method">呼び出すメソッド名</param>
+    /// <param name="paramsJson">メソッドのパラメータを表す JSON 文字列。オブジェクト形式 (例: {"key":"value"}) または配列形式 (例: [1,2,3]) で指定します。パラメータがない場合は "{}" を指定してください</param>
+    /// <param name="onResult">Sora レスポンス用のコールバック</param>
+    /// <param name="timeoutMillis">Sora レスポンスのタイムアウト時間 (ミリ秒)。0 より大きな値を指定してください</param>
+    public void SendRpcMessage(string method, string paramsJson, Action<RpcResult> onResult, long timeoutMillis)
+    {
+        if (method == null)
+        {
+            throw new ArgumentNullException(nameof(method));
+        }
+        if (paramsJson == null)
+        {
+            throw new ArgumentNullException(nameof(paramsJson));
+        }
+        if (onResult == null)
+        {
+            throw new ArgumentNullException(nameof(onResult));
+        }
+        if (timeoutMillis <= 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(timeoutMillis),
+                timeoutMillis,
+                "timeoutMillis は 0 より大きな値を指定してください。");
+        }
+
+        long id;
+        // レスポンスまでのタイムアウト時間を生成します
+        var deadlineMillis = GetNowMillis() + timeoutMillis;
+        lock (rpcLock)
+        {
+            // リクエスト ID を自動採番で生成します
+            id = nextRpcRequestId++;
+            pendingRpcRequests[id] = new PendingRpc(deadlineMillis, method, paramsJson, onResult);
+        }
+
         var methodJson = EscapeJsonString(method);
-        var rpcMessage = $"{{\"jsonrpc\":\"2.0\",\"method\":{methodJson},\"params\":{paramsJson},\"id\":{idJson}}}";
-        SendRpcMessage(rpcMessage);
-    }
-
-    /// <summary>
-    /// JSON-RPC 2.0 リクエスト (Request) を送信します。
-    /// </summary>
-    /// <remarks>
-    /// ID を付与した JSON-RPC 2.0 リクエストとして送信され、
-    /// Sora からのレスポンスは OnRpc に設定した関数に JSON-RPC 2.0 レスポンスオブジェクトの形式でコールバックされます。
-    /// </remarks>
-    /// <param name="method">呼び出すメソッド名</param>
-    /// <param name="paramsJson">メソッドのパラメータを表す JSON 文字列。オブジェクト形式 (例: {"key":"value"}) または配列形式 (例: [1,2,3]) で指定します。パラメータがない場合は "{}" を指定してください</param>
-    /// <param name="id">JSON-RPC 2.0 リクエスト ID (文字列)</param>
-    public void RequestRpc(string method, string paramsJson, string id)
-    {
-        RequestRpcInternal(method, paramsJson, EscapeJsonString(id));
-    }
-
-    /// <summary>
-    /// JSON-RPC 2.0 リクエスト (Request) を送信します。
-    /// </summary>
-    /// <remarks>
-    /// ID を付与した JSON-RPC 2.0 リクエストとして送信され、
-    /// Sora からのレスポンスは OnRpc に設定した関数に JSON-RPC 2.0 レスポンスオブジェクトの形式でコールバックされます。
-    /// </remarks>
-    /// <param name="method">呼び出すメソッド名</param>
-    /// <param name="paramsJson">メソッドのパラメータを表す JSON 文字列。オブジェクト形式 (例: {"key":"value"}) または配列形式 (例: [1,2,3]) で指定します。パラメータがない場合は "{}" を指定してください</param>
-    /// <param name="id">JSON-RPC 2.0 リクエスト ID (数値)</param>
-    public void RequestRpc(string method, string paramsJson, int id)
-    {
-        RequestRpcInternal(method, paramsJson, id.ToString());
+        var rpcMessage = $"{{\"jsonrpc\":\"2.0\",\"method\":{methodJson},\"params\":{paramsJson},\"id\":{id}}}";
+        SendRpcRawMessage(rpcMessage);
     }
 
     private delegate void DeviceEnumCallbackDelegate(string device_name, string unique_name, IntPtr userdata);

--- a/SoraUnitySdkExamples/Assets/SoraUnitySdk/Sora.cs
+++ b/SoraUnitySdkExamples/Assets/SoraUnitySdk/Sora.cs
@@ -1646,7 +1646,7 @@ public class Sora : IDisposable
     /// </remarks>
     /// <param name="method">呼び出すメソッド名</param>
     /// <param name="paramsJson">メソッドのパラメータを表す JSON 文字列。オブジェクト形式 (例: {"key":"value"}) または配列形式 (例: [1,2,3]) で指定します。パラメータがない場合は "{}" を指定してください</param>
-    public void SendRpcNotification(string method, string paramsJson)
+    public void RequestRpcNotification(string method, string paramsJson)
     {
         if (method == null)
         {
@@ -1663,7 +1663,7 @@ public class Sora : IDisposable
     }
 
     /// <summary>
-    /// JSON-RPC 2.0 メッセージを送信します。
+    /// JSON-RPC 2.0 リクエスト (Request) を送信します。
     /// </summary>
     /// <remarks>
     /// Sora への送信後、レスポンスが返ってくるまでのタイムアウト時間は 5,000 ms です。
@@ -1674,13 +1674,13 @@ public class Sora : IDisposable
     /// <param name="method">呼び出すメソッド名</param>
     /// <param name="paramsJson">メソッドのパラメータを表す JSON 文字列。オブジェクト形式 (例: {"key":"value"}) または配列形式 (例: [1,2,3]) で指定します。パラメータがない場合は "{}" を指定してください</param>
     /// <param name="onResult">Sora レスポンス用のコールバック</param>
-    public void SendRpcMessage(string method, string paramsJson, Action<RpcResult> onResult)
+    public void RequestRpc(string method, string paramsJson, Action<RpcResult> onResult)
     {
-        SendRpcMessage(method, paramsJson, onResult, DefaultRpcTimeoutMillis);
+        RequestRpc(method, paramsJson, onResult, DefaultRpcTimeoutMillis);
     }
 
     /// <summary>
-    /// JSON-RPC 2.0 メッセージを送信します。
+    /// JSON-RPC 2.0 リクエスト (Request) を送信します。
     /// </summary>
     /// <remarks>
     /// レスポンス受信とタイムアウト判定は DispatchEvents() の呼び出しで処理されます。
@@ -1691,7 +1691,7 @@ public class Sora : IDisposable
     /// <param name="paramsJson">メソッドのパラメータを表す JSON 文字列。オブジェクト形式 (例: {"key":"value"}) または配列形式 (例: [1,2,3]) で指定します。パラメータがない場合は "{}" を指定してください</param>
     /// <param name="onResult">Sora レスポンス用のコールバック</param>
     /// <param name="timeoutMillis">Sora レスポンスのタイムアウト時間 (ミリ秒)。0 より大きな値を指定してください</param>
-    public void SendRpcMessage(string method, string paramsJson, Action<RpcResult> onResult, long timeoutMillis)
+    public void RequestRpc(string method, string paramsJson, Action<RpcResult> onResult, long timeoutMillis)
     {
         if (method == null)
         {

--- a/SoraUnitySdkExamples/Assets/SoraUnitySdk/Sora.cs
+++ b/SoraUnitySdkExamples/Assets/SoraUnitySdk/Sora.cs
@@ -1289,7 +1289,7 @@ public class Sora : IDisposable
     }
 
     // レスポンス待ちの全ての RPC リクエストをキャンセルします。
-    // Dispose で呼び出されます。
+    // Dispose と切断時に呼び出されます。
     void CancelAllPendingRpc()
     {
         List<PendingRpc> cancelTargets;
@@ -1443,7 +1443,12 @@ public class Sora : IDisposable
     static private void DisconnectCallback(int errorCode, string message, IntPtr userdata)
     {
         var sora = GCHandle.FromIntPtr(userdata).Target as Sora;
+        // 切断が発生したら未完了 RPC はキャンセル扱いとします。
         sora!.CancelAllPendingRpc();
+        lock (sora!.rpcLock)
+        {
+            sora!.rpcResponseJsonQueue.Clear();
+        }
         sora!.onDisconnect!((SoraConf.ErrorCode)errorCode, message);
     }
 
@@ -1678,6 +1683,7 @@ public class Sora : IDisposable
     /// Sora への送信後、レスポンスが返ってくるまでのタイムアウト時間は 5,000 ms です。
     /// レスポンス受信とタイムアウト判定は DispatchEvents() の呼び出しで処理されます。
     /// DispatchEvents() を定期的に呼び出さない場合、onResult は呼ばれず、タイムアウトも返りません。
+    /// 切断が発生した場合、未完了の RPC は Canceled として返されます。
     /// ResultKind は成功 / 失敗を表しません。 ResponseJson の内容を利用者側で判定してください。
     /// </remarks>
     /// <param name="method">呼び出すメソッド名</param>
@@ -1694,6 +1700,7 @@ public class Sora : IDisposable
     /// <remarks>
     /// レスポンス受信とタイムアウト判定は DispatchEvents() の呼び出しで処理されます。
     /// DispatchEvents() を定期的に呼び出さない場合、onResult は呼ばれず、タイムアウトも返りません。
+    /// 切断が発生した場合、未完了の RPC は Canceled として返されます。
     /// ResultKind は成功 / 失敗を表しません。 ResponseJson の内容を利用者側で判定してください。
     /// </remarks>
     /// <param name="method">呼び出すメソッド名</param>


### PR DESCRIPTION
RPC リクエスト後、一定時間レスポンスが返ってこなかった場合はタイムアウトするようにする
- onRPC を廃止し、SendRPCMessage の引数に渡したコールバックで結果を受け取るようにする
- リクエスト ID を外から渡せないようにして、内部で採番するようにする
- リクエストは送信時にリクエストIDをキーとした辞書に格納され、レスポンス待ちリクエストとして管理される
- レスポンス待ちリクエストは リクエストID で管理するため、レスポンスの Json 文字列から ID だけパースして利用する
- レスポンスの中身のデータは引き続き生のJson文字列が返されるので利用者側でパースする