### PR TITLE
RPC タイムアウトの処理を修正する

### DIFF
--- a/SoraUnitySdkExamples/.vscode/settings.json
+++ b/SoraUnitySdkExamples/.vscode/settings.json
@@ -52,5 +52,5 @@
         "temp/": true,
         "Temp/": true
     },
-    "dotnet.defaultSolution": "SoraUnitySdkExamples.sln"
+    "dotnet.defaultSolution": "SoraUnitySdkExamples.slnx"
 }

--- a/SoraUnitySdkExamples/Assets/SoraSample.cs
+++ b/SoraUnitySdkExamples/Assets/SoraSample.cs
@@ -1234,11 +1234,6 @@ public class SoraSample : MonoBehaviour
             Debug.LogErrorFormat("RPC timeoutMillis の形式が不正です: timeoutMillis={0}", rpcTimeoutMillis);
             return;
         }
-        if (timeoutMillis <= 0)
-        {
-            Debug.LogErrorFormat("RPC timeoutMillis は 1 以上を指定してください: timeoutMillis={0}", timeoutMillis);
-            return;
-        }
 
         sora.RequestRpc(method, paramsJson, HandleRpcResult, timeoutMillis);
     }

--- a/SoraUnitySdkExamples/Assets/SoraSample.cs
+++ b/SoraUnitySdkExamples/Assets/SoraSample.cs
@@ -1206,7 +1206,7 @@ public class SoraSample : MonoBehaviour
     {
         switch (result.ResultKind)
         {
-            case Sora.RpcResultKind.ResponseReceived:
+            case Sora.RpcResultKind.Response:
                 Debug.LogFormat("RPC response: method={0}, response={1}", result.Method, result.ResponseJson);
                 break;
             case Sora.RpcResultKind.Timeout:

--- a/SoraUnitySdkExamples/Assets/SoraSample.cs
+++ b/SoraUnitySdkExamples/Assets/SoraSample.cs
@@ -1224,7 +1224,7 @@ public class SoraSample : MonoBehaviour
 
         if (string.IsNullOrWhiteSpace(rpcTimeoutMillis))
         {
-            sora.RequestRpc(method, paramsJson, HandleRpcResult);
+            sora.RequestRpc(method, paramsJson, HandleRpcResult, Sora.DefaultRpcTimeoutMillis);
             return;
         }
 

--- a/SoraUnitySdkExamples/Assets/SoraSample.cs
+++ b/SoraUnitySdkExamples/Assets/SoraSample.cs
@@ -1212,9 +1212,6 @@ public class SoraSample : MonoBehaviour
             case Sora.RpcResultKind.Timeout:
                 Debug.LogErrorFormat("RPC timeout: method={0}", result.Method);
                 break;
-            case Sora.RpcResultKind.Canceled:
-                Debug.LogWarningFormat("RPC canceled: method={0}", result.Method);
-                break;
         }
     }
 

--- a/SoraUnitySdkExamples/Assets/SoraUnitySdk/Sora.cs
+++ b/SoraUnitySdkExamples/Assets/SoraUnitySdk/Sora.cs
@@ -500,12 +500,12 @@ public class Sora : IDisposable
     UnityEngine.Rendering.CommandBuffer commandBuffer;
     UnityEngine.Camera? unityCamera;
 
-    // RPC リクエスト結果 Enum
+    // RPC リクエストの結果の種類
     public enum RpcResultKind
     {
-        // レスポンスを受信しました（result と error の判別は行いません）
+        // レスポンス（result と error の判別は行わない）
         Response,
-        // タイムアウトしました
+        // タイムアウト
         Timeout,
     }
     // RPC レスポンスの構造体
@@ -516,7 +516,8 @@ public class Sora : IDisposable
         public readonly string Method;
         // リクエストパラメータ Json 文字列
         public readonly string ParamsJson;
-        // レスポンス Json 文字列。データ内容のパースは SDK の利用者側の責務となります
+        // レスポンス Json 文字列。データ内容のパースは SDK の利用者側の責務となる
+        // ResultKind が Timeout の場合は null になり、Response の場合は非 null になる
         public readonly string? ResponseJson;
 
         public RpcResult(
@@ -533,7 +534,7 @@ public class Sora : IDisposable
     }
 
     // RPC リクエスト後にレスポンスを待つタイムアウト時間のデフォルト
-    const long DefaultRpcTimeoutMillis = 5000;
+    public const long DefaultRpcTimeoutMillis = 5000;
 
     // 非同期で実行された RPC リクエストがレスポンスを待っている間に保持される情報の構造体
     struct PendingRpc
@@ -556,15 +557,12 @@ public class Sora : IDisposable
         }
     }
 
-    // RPC レスポンスキュー、ID 採番等の RPC に関する共有データを排他制御するためのロック
-    readonly object rpcLock = new object();
     // RPC レスポンスを Unity スレッド上で順番に処理するためのキュー
     readonly Queue<string> rpcResponseJsonQueue = new Queue<string>();
     // RPC リクエスト送信済みでレスポンス待ちになっているリクエストを保持する辞書。リクエスト ID をキーとします
     readonly Dictionary<long, PendingRpc> pendingRpcRequests = new Dictionary<long, PendingRpc>();
     // RPC リクエスト ID
-    // リクエストとレスポンスコンテキストの紐付けに利用されますが、 
-    // `pendingRpcRequests` のキーとしても利用されます。重複を防ぐため自動採番としています。
+    // RPC リクエストとレスポンスの紐付けに利用する
     long nextRpcRequestId = 1;
 
     /// <summary>
@@ -583,6 +581,12 @@ public class Sora : IDisposable
             sora_destroy(p);
             p = IntPtr.Zero;
         }
+
+        lock (rpcResponseJsonQueue)
+        {
+            rpcResponseJsonQueue.Clear();
+        }
+        pendingRpcRequests.Clear();
 
         foreach (var adapter in audioTrackSinks.Values)
         {
@@ -1258,7 +1262,10 @@ public class Sora : IDisposable
     static private void RpcCallback(string json, IntPtr userdata)
     {
         var sora = GCHandle.FromIntPtr(userdata).Target as Sora;
-        sora!.EnqueueRpcResponseJson(json);
+        lock (sora!.rpcResponseJsonQueue)
+        {
+            sora.rpcResponseJsonQueue.Enqueue(json);
+        }
     }
 
     // RPC リクエストタイムアウト時間算出のための基準時間を生成
@@ -1271,56 +1278,43 @@ public class Sora : IDisposable
         return nowStopwatch.ElapsedMilliseconds;
     }
 
-    void EnqueueRpcResponseJson(string json)
-    {
-        lock (rpcLock)
-        {
-            rpcResponseJsonQueue.Enqueue(json);
-        }
-    }
-
-    // RPC レスポンスハンドリング
+    // RPC レスポンスのハンドリング
     // DispatchEvents() から呼ばれる前提で、必ず Unity スレッドで実行されます。
-    // ネイティブから RPC レスポンスが別スレッドで来た場合は、キューに積まれたものをここで処理します。
+    // キューに積まれたものをここで処理します。
     void HandleRpcInternal()
     {
         while (true)
         {
             string? responseJson = null;
-            lock (rpcLock)
+            lock (rpcResponseJsonQueue)
             {
-                // キューから1つずつ取り出して処理します
-                if (rpcResponseJsonQueue.Count != 0)
+                if (rpcResponseJsonQueue.Count == 0)
                 {
-                    responseJson = rpcResponseJsonQueue.Dequeue();
+                    break;
                 }
-            }
-
-            // Dequeue できなかった場合はキューが空となっているため抜けます
-            if (responseJson == null)
-            {
-                break;
+                responseJson = rpcResponseJsonQueue.Dequeue();
             }
 
             // レスポンスデータの JSON 文字列から、リクエスト ID のみを抜き出します。
-            // ID が取得できない場合はレスポンス待ちと紐付けできないため捨てます。
-            var id = JsonRpcUtil.ParseId(responseJson);
-            if (id == 0)
+            // ID が取得できない場合や JSON 文字列が不正な場合はレスポンス待ちと紐付けできないため捨てます。
+            long id;
+            try
+            {
+                id = JsonUtility.FromJson<JsonRpcResponseIdOnly>(responseJson).id;
+            }
+            catch (Exception)
             {
                 continue;
             }
 
             PendingRpc pending;
-            lock (rpcLock)
+            // レスポンス待ち辞書からリクエスト ID で抽出し、処理済みとして除去します。
+            // 辞書内に見つからない場合は既に（主にタイムアウトの）レスポンスを返しているとみなし何もしません。
+            if (!pendingRpcRequests.TryGetValue(id, out pending))
             {
-                // レスポンス待ち辞書からリクエスト ID で抽出し、処理済みとして除去します。
-                // 辞書内に見つからない場合は既にレスポンスを返しているとみなし何もしません。
-                if (!pendingRpcRequests.TryGetValue(id, out pending))
-                {
-                    continue;
-                }
-                pendingRpcRequests.Remove(id);
+                continue;
             }
+            pendingRpcRequests.Remove(id);
 
             // RPC 結果をコールバックで返します
             pending.OnResult(new RpcResult(
@@ -1330,38 +1324,23 @@ public class Sora : IDisposable
                 responseJson));
         }
 
-        // レスポンス待ちリクエストがなければ抜けます
-        lock (rpcLock)
-        {
-            if (pendingRpcRequests.Count == 0)
-            {
-                return;
-            }
-        }
-
         // レスポンス待ちリクエストのタイムアウト処理を行います
         List<PendingRpc> timeoutTargets = new List<PendingRpc>();
         var nowMillis = GetNowMillis();
-        lock (rpcLock)
+        var timeoutIds = new List<long>();
+        foreach (var kv in pendingRpcRequests)
         {
-            if (pendingRpcRequests.Count != 0)
+            // タイムアウト時間を過ぎている場合、タイムアウト対象リストに追加します
+            if (nowMillis >= kv.Value.DeadlineMillis)
             {
-                var timeoutIds = new List<long>();
-                foreach (var kv in pendingRpcRequests)
-                {
-                    // タイムアウト時間を過ぎているか判定し、タイムアウト対象IDリストに追加します
-                    if (nowMillis >= kv.Value.DeadlineMillis)
-                    {
-                        timeoutIds.Add(kv.Key);
-                    }
-                }
-                // タイムアウトターゲットリストの作成とレスポンス待ちリクエストリストからの除去を行います
-                foreach (var id in timeoutIds)
-                {
-                    timeoutTargets.Add(pendingRpcRequests[id]);
-                    pendingRpcRequests.Remove(id);
-                }
+                timeoutIds.Add(kv.Key);
+                timeoutTargets.Add(kv.Value);
             }
+        }
+        // レスポンス待ちリクエストからの除去を行います
+        foreach (var id in timeoutIds)
+        {
+            pendingRpcRequests.Remove(id);
         }
 
         // タイムアウトとなったリクエストを Timeout でコールバックとして返します
@@ -1382,24 +1361,6 @@ public class Sora : IDisposable
         public string jsonrpc = "";
         // サーバーが数値 id を返す前提
         public long id;
-    }
-
-    static class JsonRpcUtil
-    {
-        // JsonRpcUtil 経由での関数呼び出しとすることでデータ型にパース手段が生えない設計にしています。
-        // ID が取得できない場合はエラーを握りつぶし 0 を返します。
-        // レスポンス待ちと紐付けできないため呼び出し元で捨てられます。
-        public static long ParseId(string json)
-        {
-            try
-            {
-                return JsonUtility.FromJson<JsonRpcResponseIdOnly>(json).id;
-            }
-            catch (Exception)
-            {
-                return 0;
-            }
-        }
     }
 
     private delegate void DisconnectCallbackDelegate(int errorCode, string message, IntPtr userdata);
@@ -1445,9 +1406,7 @@ public class Sora : IDisposable
     /// OnAddTrack や OnRemoveTrack, OnDisconnect といったコールバックは、一部を除き、この関数を呼び出すことで発生します。
     /// そのため、この関数は Update() などの定期的に実行される場所で呼び出すようにして下さい。
     ///
-    /// RPC のレスポンス受信もこの関数の呼び出しで処理されます。
-    /// ネイティブからの RPC レスポンス到達自体は Unity スレッドとは別のスレッドで発生する可能性がありますが、
-    /// 内部でキューに積み、DispatchEvents() 内で Unity スレッド上の処理に寄せています。
+    /// RPC リクエストのレスポンス受信もこの関数の呼び出しで処理されます。
     ///
     /// 例外として、OnHandleAudio と OnCapturerFrame はこの関数を呼ばなくても発生しますが、
     /// Unity スレッドとは別のスレッドから呼び出されるため同期に注意する必要があります。
@@ -1639,26 +1598,19 @@ public class Sora : IDisposable
     /// JSON-RPC 2.0 リクエスト (Request) を送信します。
     /// </summary>
     /// <remarks>
-    /// Sora への送信後、レスポンスが返ってくるまでのタイムアウト時間は 5,000 ms です。
-    /// レスポンス受信とタイムアウト判定は DispatchEvents() の呼び出しで処理されます。
-    /// DispatchEvents() を定期的に呼び出さない場合、onResult は呼ばれず、タイムアウトも返りません。
-    /// ResultKind は成功 / 失敗を表しません。 ResponseJson の内容を利用者側で判定してください。
-    /// </remarks>
-    /// <param name="method">呼び出すメソッド名</param>
-    /// <param name="paramsJson">メソッドのパラメータを表す JSON 文字列。オブジェクト形式 (例: {"key":"value"}) または配列形式 (例: [1,2,3]) で指定します。パラメータがない場合は "{}" を指定してください</param>
-    /// <param name="onResult">Sora レスポンス用のコールバック</param>
-    public void RequestRpc(string method, string paramsJson, Action<RpcResult> onResult)
-    {
-        RequestRpc(method, paramsJson, onResult, DefaultRpcTimeoutMillis);
-    }
-
-    /// <summary>
-    /// JSON-RPC 2.0 リクエスト (Request) を送信します。
-    /// </summary>
-    /// <remarks>
-    /// レスポンス受信とタイムアウト判定は DispatchEvents() の呼び出しで処理されます。
-    /// DispatchEvents() を定期的に呼び出さない場合、onResult は呼ばれず、タイムアウトも返りません。
-    /// ResultKind は成功 / 失敗を表しません。 ResponseJson の内容を利用者側で判定してください。
+    /// レスポンス受信とタイムアウト判定の処理は DispatchEvents() の呼び出しで行われ、
+    /// onResult コールバックも DispatchEvents() 関数内からのみ発生します。
+    /// 
+    /// そのため DispatchEvents() を定期的に呼び出さない場合、
+    /// onResult コールバックが発生しなくなるので注意して下さい。
+    /// 
+    /// onResult の引数で渡される RpcResult 型の値には ResultKind メンバーが含まれており、
+    /// 
+    /// - ResultKind.Response は JSON-RPC レスポンスオブジェクトを受信したことを表します。
+    /// - ResultKind.Timeout は指定したタイムアウト時間内にレスポンスを受信できなかったことを表します。
+    /// 
+    /// JSON-RPC レスポンスオブジェクトが成功なのか失敗なのかに関しては、
+    /// 利用者側で ResponseJson の内容をパースして判定してください。
     /// </remarks>
     /// <param name="method">呼び出すメソッド名</param>
     /// <param name="paramsJson">メソッドのパラメータを表す JSON 文字列。オブジェクト形式 (例: {"key":"value"}) または配列形式 (例: [1,2,3]) で指定します。パラメータがない場合は "{}" を指定してください</param>
@@ -1689,12 +1641,9 @@ public class Sora : IDisposable
         long id;
         // レスポンスまでのタイムアウト時間を生成します
         var deadlineMillis = GetNowMillis() + timeoutMillis;
-        lock (rpcLock)
-        {
-            // リクエスト ID を自動採番で生成します
-            id = nextRpcRequestId++;
-            pendingRpcRequests[id] = new PendingRpc(deadlineMillis, method, paramsJson, onResult);
-        }
+        // リクエスト ID を自動採番で生成します
+        id = nextRpcRequestId++;
+        pendingRpcRequests[id] = new PendingRpc(deadlineMillis, method, paramsJson, onResult);
 
         var methodJson = EscapeJsonString(method);
         var rpcMessage = $"{{\"jsonrpc\":\"2.0\",\"method\":{methodJson},\"params\":{paramsJson},\"id\":{id}}}";

--- a/SoraUnitySdkExamples/Assets/SoraUnitySdk/Sora.cs
+++ b/SoraUnitySdkExamples/Assets/SoraUnitySdk/Sora.cs
@@ -1706,7 +1706,7 @@ public class Sora : IDisposable
     /// <param name="method">呼び出すメソッド名</param>
     /// <param name="paramsJson">メソッドのパラメータを表す JSON 文字列。オブジェクト形式 (例: {"key":"value"}) または配列形式 (例: [1,2,3]) で指定します。パラメータがない場合は "{}" を指定してください</param>
     /// <param name="onResult">Sora レスポンス用のコールバック</param>
-    /// <param name="timeoutMillis">Sora レスポンスのタイムアウト時間 (ミリ秒)。0 より大きな値を指定してください</param>
+    /// <param name="timeoutMillis">Sora レスポンスのタイムアウト時間 (ミリ秒)。0 以上の値を指定してください</param>
     public void RequestRpc(string method, string paramsJson, Action<RpcResult> onResult, long timeoutMillis)
     {
         if (method == null)
@@ -1721,12 +1721,12 @@ public class Sora : IDisposable
         {
             throw new ArgumentNullException(nameof(onResult));
         }
-        if (timeoutMillis <= 0)
+        if (timeoutMillis < 0)
         {
             throw new ArgumentOutOfRangeException(
                 nameof(timeoutMillis),
                 timeoutMillis,
-                "timeoutMillis は 0 より大きな値を指定してください。");
+                "timeoutMillis は 0 以上の値を指定してください。");
         }
 
         long id;

--- a/SoraUnitySdkExamples/Assets/SoraUnitySdk/Sora.cs
+++ b/SoraUnitySdkExamples/Assets/SoraUnitySdk/Sora.cs
@@ -504,7 +504,7 @@ public class Sora : IDisposable
     public enum RpcResultKind
     {
         // レスポンスを受信しました（result と error の判別は行いません）
-        ResponseReceived,
+        Response,
         // タイムアウトしました
         Timeout,
     }
@@ -1324,7 +1324,7 @@ public class Sora : IDisposable
 
             // RPC 結果をコールバックで返します
             pending.OnResult(new RpcResult(
-                RpcResultKind.ResponseReceived,
+                RpcResultKind.Response,
                 pending.Method,
                 pending.ParamsJson,
                 responseJson));

--- a/SoraUnitySdkExamples/Assets/SoraUnitySdk/Sora.cs
+++ b/SoraUnitySdkExamples/Assets/SoraUnitySdk/Sora.cs
@@ -537,7 +537,7 @@ public class Sora : IDisposable
     public const long DefaultRpcTimeoutMillis = 5000;
 
     // 非同期で実行された RPC リクエストがレスポンスを待っている間に保持される情報の構造体
-    struct PendingRpc
+    struct PendingRpcRequest
     {
         // タイムアウト用の期限
         public long DeadlineMillis;
@@ -548,7 +548,7 @@ public class Sora : IDisposable
         // RPC レスポンス用のコールバック
         public Action<RpcResult> OnResult;
 
-        public PendingRpc(long deadlineMillis, string method, string paramsJson, Action<RpcResult> onResult)
+        public PendingRpcRequest(long deadlineMillis, string method, string paramsJson, Action<RpcResult> onResult)
         {
             DeadlineMillis = deadlineMillis;
             Method = method;
@@ -560,7 +560,7 @@ public class Sora : IDisposable
     // RPC レスポンスを Unity スレッド上で順番に処理するためのキュー
     readonly Queue<string> rpcResponseJsonQueue = new Queue<string>();
     // RPC リクエスト送信済みでレスポンス待ちになっているリクエストを保持する辞書。リクエスト ID をキーとします
-    readonly Dictionary<long, PendingRpc> pendingRpcRequests = new Dictionary<long, PendingRpc>();
+    readonly Dictionary<long, PendingRpcRequest> pendingRpcRequests = new Dictionary<long, PendingRpcRequest>();
     // RPC リクエスト ID
     // RPC リクエストとレスポンスの紐付けに利用する
     long nextRpcRequestId = 1;
@@ -1279,7 +1279,7 @@ public class Sora : IDisposable
     }
 
     // RPC レスポンスのハンドリング
-    // DispatchEvents() から呼ばれる前提で、必ず Unity スレッドで実行されます。
+    // DispatchEvents() から呼ばれる関数で、必ず Unity スレッドで実行されます。
     // キューに積まれたものをここで処理します。
     void HandleRpcInternal()
     {
@@ -1307,7 +1307,7 @@ public class Sora : IDisposable
                 continue;
             }
 
-            PendingRpc pending;
+            PendingRpcRequest pending;
             // レスポンス待ち辞書からリクエスト ID で抽出し、処理済みとして除去します。
             // 辞書内に見つからない場合は既に（主にタイムアウトの）レスポンスを返しているとみなし何もしません。
             if (!pendingRpcRequests.TryGetValue(id, out pending))
@@ -1325,7 +1325,7 @@ public class Sora : IDisposable
         }
 
         // レスポンス待ちリクエストのタイムアウト処理を行います
-        List<PendingRpc> timeoutTargets = new List<PendingRpc>();
+        List<PendingRpcRequest> timeoutTargets = new List<PendingRpcRequest>();
         var nowMillis = GetNowMillis();
         var timeoutIds = new List<long>();
         foreach (var kv in pendingRpcRequests)
@@ -1589,24 +1589,23 @@ public class Sora : IDisposable
     /// JSON-RPC 2.0 リクエスト (Request) を送信します。
     /// </summary>
     /// <remarks>
-    /// レスポンス受信とタイムアウト判定の処理は DispatchEvents() の呼び出しで行われ、
+    /// リクエストに対するレスポンスの受信とタイムアウト判定の処理は DispatchEvents() の呼び出しで行われ、
     /// onResult コールバックも DispatchEvents() 関数内からのみ発生します。
     /// 
-    /// そのため DispatchEvents() を定期的に呼び出さない場合、
-    /// onResult コールバックが発生しなくなるので注意して下さい。
+    /// そのため DispatchEvents() を定期的に呼び出すようにしてください。
     /// 
     /// onResult の引数で渡される RpcResult 型の値には ResultKind メンバーが含まれており、
     /// 
-    /// - ResultKind.Response は JSON-RPC レスポンスオブジェクトを受信したことを表します。
-    /// - ResultKind.Timeout は指定したタイムアウト時間内にレスポンスを受信できなかったことを表します。
+    /// - ResultKind が RpcResultKind.Response だった場合は JSON-RPC レスポンスオブジェクトを受信したことを表し、ResponseJson に JSON-RPC レスポンスオブジェクトの JSON 文字列が格納されます。
+    /// - ResultKind が RpcResultKind.Timeout だった場合は指定したタイムアウト時間内にレスポンスを受信できなかったことを表し、 ResponseJson は null になります。
     /// 
-    /// JSON-RPC レスポンスオブジェクトが成功なのか失敗なのかに関しては、
+    /// JSON-RPC レスポンスオブジェクトが成功の結果なのか失敗の結果なのかに関しては、
     /// 利用者側で ResponseJson の内容をパースして判定してください。
     /// </remarks>
     /// <param name="method">呼び出すメソッド名</param>
     /// <param name="paramsJson">メソッドのパラメータを表す JSON 文字列。オブジェクト形式 (例: {"key":"value"}) または配列形式 (例: [1,2,3]) で指定します。パラメータがない場合は "{}" を指定してください</param>
-    /// <param name="onResult">Sora レスポンス用のコールバック</param>
-    /// <param name="timeoutMillis">Sora レスポンスのタイムアウト時間 (ミリ秒)。0 以上の値を指定してください</param>
+    /// <param name="onResult">レスポンス用のコールバック</param>
+    /// <param name="timeoutMillis">レスポンスのタイムアウト時間 (ミリ秒)。0 以上の値を指定してください</param>
     public void RequestRpc(string method, string paramsJson, Action<RpcResult> onResult, long timeoutMillis)
     {
         if (timeoutMillis < 0)
@@ -1617,12 +1616,11 @@ public class Sora : IDisposable
                 "timeoutMillis は 0 以上の値を指定してください。");
         }
 
-        long id;
         // レスポンスまでのタイムアウト時間を生成します
         var deadlineMillis = GetNowMillis() + timeoutMillis;
         // リクエスト ID を自動採番で生成します
-        id = nextRpcRequestId++;
-        pendingRpcRequests[id] = new PendingRpc(deadlineMillis, method, paramsJson, onResult);
+        long id = nextRpcRequestId++;
+        pendingRpcRequests[id] = new PendingRpcRequest(deadlineMillis, method, paramsJson, onResult);
 
         var methodJson = EscapeJsonString(method);
         var rpcMessage = $"{{\"jsonrpc\":\"2.0\",\"method\":{methodJson},\"params\":{paramsJson},\"id\":{id}}}";

--- a/SoraUnitySdkExamples/Assets/SoraUnitySdk/Sora.cs
+++ b/SoraUnitySdkExamples/Assets/SoraUnitySdk/Sora.cs
@@ -507,8 +507,6 @@ public class Sora : IDisposable
         ResponseReceived,
         // タイムアウトしました
         Timeout,
-        // 破棄や切断によりキャンセルされました
-        Canceled,
     }
     // RPC レスポンスの構造体
     public readonly struct RpcResult
@@ -580,13 +578,6 @@ public class Sora : IDisposable
     /// </remarks>
     public void Dispose()
     {
-        // レスポンス待ちになっている RPC リクエストを全てキャンセルする
-        CancelAllPendingRpc();
-        lock (rpcLock)
-        {
-            rpcResponseJsonQueue.Clear();
-        }
-
         if (p != IntPtr.Zero)
         {
             sora_destroy(p);
@@ -1288,32 +1279,6 @@ public class Sora : IDisposable
         }
     }
 
-    // レスポンス待ちの全ての RPC リクエストをキャンセルします。
-    // Dispose と切断時に呼び出されます。
-    void CancelAllPendingRpc()
-    {
-        List<PendingRpc> cancelTargets;
-        lock (rpcLock)
-        {
-            if (pendingRpcRequests.Count == 0)
-            {
-                return;
-            }
-            cancelTargets = new List<PendingRpc>(pendingRpcRequests.Values);
-            pendingRpcRequests.Clear();
-        }
-
-        // キャンセル扱いで結果をコールバックで返します
-        foreach (var pending in cancelTargets)
-        {
-            pending.OnResult(new RpcResult(
-                RpcResultKind.Canceled,
-                pending.Method,
-                pending.ParamsJson,
-                null));
-        }
-    }
-
     // RPC レスポンスハンドリング
     // DispatchEvents() から呼ばれる前提で、必ず Unity スレッドで実行されます。
     // ネイティブから RPC レスポンスが別スレッドで来た場合は、キューに積まれたものをここで処理します。
@@ -1443,12 +1408,6 @@ public class Sora : IDisposable
     static private void DisconnectCallback(int errorCode, string message, IntPtr userdata)
     {
         var sora = GCHandle.FromIntPtr(userdata).Target as Sora;
-        // 切断が発生したら未完了 RPC はキャンセル扱いとします。
-        sora!.CancelAllPendingRpc();
-        lock (sora!.rpcLock)
-        {
-            sora!.rpcResponseJsonQueue.Clear();
-        }
         sora!.onDisconnect!((SoraConf.ErrorCode)errorCode, message);
     }
 
@@ -1683,7 +1642,6 @@ public class Sora : IDisposable
     /// Sora への送信後、レスポンスが返ってくるまでのタイムアウト時間は 5,000 ms です。
     /// レスポンス受信とタイムアウト判定は DispatchEvents() の呼び出しで処理されます。
     /// DispatchEvents() を定期的に呼び出さない場合、onResult は呼ばれず、タイムアウトも返りません。
-    /// 切断が発生した場合、未完了の RPC は Canceled として返されます。
     /// ResultKind は成功 / 失敗を表しません。 ResponseJson の内容を利用者側で判定してください。
     /// </remarks>
     /// <param name="method">呼び出すメソッド名</param>
@@ -1700,7 +1658,6 @@ public class Sora : IDisposable
     /// <remarks>
     /// レスポンス受信とタイムアウト判定は DispatchEvents() の呼び出しで処理されます。
     /// DispatchEvents() を定期的に呼び出さない場合、onResult は呼ばれず、タイムアウトも返りません。
-    /// 切断が発生した場合、未完了の RPC は Canceled として返されます。
     /// ResultKind は成功 / 失敗を表しません。 ResponseJson の内容を利用者側で判定してください。
     /// </remarks>
     /// <param name="method">呼び出すメソッド名</param>

--- a/SoraUnitySdkExamples/Assets/SoraUnitySdk/Sora.cs
+++ b/SoraUnitySdkExamples/Assets/SoraUnitySdk/Sora.cs
@@ -1285,7 +1285,7 @@ public class Sora : IDisposable
     {
         while (true)
         {
-            string? responseJson = null;
+            string responseJson;
             lock (rpcResponseJsonQueue)
             {
                 if (rpcResponseJsonQueue.Count == 0)
@@ -1295,7 +1295,7 @@ public class Sora : IDisposable
                 responseJson = rpcResponseJsonQueue.Dequeue();
             }
 
-            // レスポンスデータの JSON 文字列から、リクエスト ID のみを抜き出します。
+            // レスポンスデータの JSON 文字列をパースして、リクエスト ID のみを抜き出します。
             // ID が取得できない場合や JSON 文字列が不正な場合はレスポンス待ちと紐付けできないため捨てます。
             long id;
             try
@@ -1580,15 +1580,6 @@ public class Sora : IDisposable
     /// <param name="paramsJson">メソッドのパラメータを表す JSON 文字列。オブジェクト形式 (例: {"key":"value"}) または配列形式 (例: [1,2,3]) で指定します。パラメータがない場合は "{}" を指定してください</param>
     public void RequestRpcNotification(string method, string paramsJson)
     {
-        if (method == null)
-        {
-            throw new ArgumentNullException(nameof(method));
-        }
-        if (paramsJson == null)
-        {
-            throw new ArgumentNullException(nameof(paramsJson));
-        }
-
         var methodJson = EscapeJsonString(method);
         var rpcMessage = $"{{\"jsonrpc\":\"2.0\",\"method\":{methodJson},\"params\":{paramsJson}}}";
         SendRpcMessage(rpcMessage);
@@ -1618,18 +1609,6 @@ public class Sora : IDisposable
     /// <param name="timeoutMillis">Sora レスポンスのタイムアウト時間 (ミリ秒)。0 以上の値を指定してください</param>
     public void RequestRpc(string method, string paramsJson, Action<RpcResult> onResult, long timeoutMillis)
     {
-        if (method == null)
-        {
-            throw new ArgumentNullException(nameof(method));
-        }
-        if (paramsJson == null)
-        {
-            throw new ArgumentNullException(nameof(paramsJson));
-        }
-        if (onResult == null)
-        {
-            throw new ArgumentNullException(nameof(onResult));
-        }
         if (timeoutMillis < 0)
         {
             throw new ArgumentOutOfRangeException(

--- a/SoraUnitySdkExamples/Assets/SoraUnitySdk/Sora.cs
+++ b/SoraUnitySdkExamples/Assets/SoraUnitySdk/Sora.cs
@@ -582,10 +582,7 @@ public class Sora : IDisposable
             p = IntPtr.Zero;
         }
 
-        lock (rpcResponseJsonQueue)
-        {
-            rpcResponseJsonQueue.Clear();
-        }
+        rpcResponseJsonQueue.Clear();
         pendingRpcRequests.Clear();
 
         foreach (var adapter in audioTrackSinks.Values)
@@ -1262,10 +1259,7 @@ public class Sora : IDisposable
     static private void RpcCallback(string json, IntPtr userdata)
     {
         var sora = GCHandle.FromIntPtr(userdata).Target as Sora;
-        lock (sora!.rpcResponseJsonQueue)
-        {
-            sora.rpcResponseJsonQueue.Enqueue(json);
-        }
+        sora!.rpcResponseJsonQueue.Enqueue(json);
     }
 
     // RPC リクエストタイムアウト時間算出のための基準時間を生成
@@ -1286,14 +1280,11 @@ public class Sora : IDisposable
         while (true)
         {
             string responseJson;
-            lock (rpcResponseJsonQueue)
+            if (rpcResponseJsonQueue.Count == 0)
             {
-                if (rpcResponseJsonQueue.Count == 0)
-                {
-                    break;
-                }
-                responseJson = rpcResponseJsonQueue.Dequeue();
+                break;
             }
+            responseJson = rpcResponseJsonQueue.Dequeue();
 
             // レスポンスデータの JSON 文字列をパースして、リクエスト ID のみを抜き出します。
             // ID が取得できない場合や JSON 文字列が不正な場合はレスポンス待ちと紐付けできないため捨てます。


### PR DESCRIPTION
#176 で気になったところを修正しました。

- タイムアウトを 0 許容にした
  - タイムアウトで 0 を許容しない設計は多分一般的には無いと思うので
- 無駄なロックを排除
  - RPC のコールバックは Unity スレッド上で発生する
- Canceled を削除
  - DispatchEvents() 以外でコールバックをしてはいけないし、OnDisconnect() や Dispose() の後に DispatchEvents() を呼び出してもいけないので意味がない
- RequestRpc() のタイムアウト無しのバージョンを削除し、その代わりに DefaultRpcTimeoutMillis を public にしてユーザー側で利用可能にする
  - ユーザーにタイムアウトがあることを意識させたいのと、オーバーロードは組み合わせ爆発を起こすのであまり使いたくない
- ResponseReceived → Response にリネーム
  - Kind としては Response が良さそうだし、短いし、これでどういう意味なのか伝わると思う
